### PR TITLE
Persist DTDD tags to library and fix refresh task seeding

### DIFF
--- a/Jellyfin.Plugin.DoesTheDogDie/ScheduledTasks/DtddRefreshTask.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/ScheduledTasks/DtddRefreshTask.cs
@@ -144,6 +144,9 @@ public class DtddRefreshTask : IScheduledTask
     {
         var items = new List<BaseItem>();
 
+        // Select all movies/series that have an IMDB ID. This lets the task do the
+        // initial population on existing libraries (which have no DTDD ID yet) as well
+        // as refresh items already tagged. Items without an IMDB ID are skipped later.
         if (config.EnableMovies)
         {
             var movies = _libraryManager.GetItemList(new InternalItemsQuery
@@ -152,7 +155,7 @@ public class DtddRefreshTask : IScheduledTask
                 IncludeItemTypes = new[] { BaseItemKind.Movie },
                 HasAnyProviderId = new Dictionary<string, string>
                 {
-                    { Constants.ProviderId, string.Empty }
+                    { MetadataProvider.Imdb.ToString(), string.Empty }
                 }
             });
             items.AddRange(movies);
@@ -166,7 +169,7 @@ public class DtddRefreshTask : IScheduledTask
                 IncludeItemTypes = new[] { BaseItemKind.Series },
                 HasAnyProviderId = new Dictionary<string, string>
                 {
-                    { Constants.ProviderId, string.Empty }
+                    { MetadataProvider.Imdb.ToString(), string.Empty }
                 }
             });
             items.AddRange(series);
@@ -205,9 +208,14 @@ public class DtddRefreshTask : IScheduledTask
         if (config.AddWarningTags)
         {
             var tagsChanged = UpdateWarningTags(item, details, config);
+            await item.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken)
+                .ConfigureAwait(false);
             return tagsChanged;
         }
 
+        // Even if tags are disabled, persist the (possibly updated) DTDD provider ID.
+        await item.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken)
+            .ConfigureAwait(false);
         return false;
     }
 

--- a/Jellyfin.Plugin.DoesTheDogDie/Services/DtddLibraryScanService.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/Services/DtddLibraryScanService.cs
@@ -134,6 +134,11 @@ public class DtddLibraryScanService : IHostedService
                 AddWarningTags(item, details, config);
             }
 
+            // Persist the provider ID and tags back to the library database.
+            // Without this, the in-memory changes are discarded when the method returns.
+            await item.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, CancellationToken.None)
+                .ConfigureAwait(false);
+
             _logger.LogInformation(
                 "Added DTDD data for {ItemName} (DTDD ID: {DtddId})",
                 item.Name,

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/ScheduledTasks/DtddRefreshTaskTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/ScheduledTasks/DtddRefreshTaskTests.cs
@@ -445,6 +445,121 @@ public class DtddRefreshTaskTests
         Assert.Contains("Safe: a dog dies", movie.Tags);
     }
 
+    [Fact]
+    public async Task ExecuteAsync_WithTagsEnabled_CallsUpdateToRepositoryAsync()
+    {
+        // Arrange
+        var config = new PluginConfiguration
+        {
+            EnableMovies = true,
+            EnableSeries = false,
+            AddWarningTags = true,
+            TagPrefix = "CW:",
+            MinVotesThreshold = 0
+        };
+        _configAccessorMock.Setup(x => x.GetConfiguration()).Returns(config);
+
+        var movieMock = new Mock<Movie> { CallBase = true };
+        movieMock.Object.Name = "Test Movie";
+        movieMock.Object.Tags = Array.Empty<string>();
+        movieMock.Object.SetProviderId(MetadataProvider.Imdb, "tt2911666");
+        movieMock.Object.SetProviderId(Constants.ProviderId, "15713");
+        movieMock.Setup(x => x.UpdateToRepositoryAsync(It.IsAny<MediaBrowser.Controller.Library.ItemUpdateType>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _libraryManagerMock
+            .Setup(x => x.GetItemList(It.IsAny<InternalItemsQuery>()))
+            .Returns(new BaseItem[] { movieMock.Object });
+
+        var details = CreateMediaDetailsWithTriggers(15713, "John Wick");
+        _apiClientMock
+            .Setup(x => x.GetMediaDetailsByImdbIdAsync("tt2911666", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        // Act
+        await _task.ExecuteAsync(new Mock<IProgress<double>>().Object, CancellationToken.None);
+
+        // Assert
+        movieMock.Verify(
+            x => x.UpdateToRepositoryAsync(MediaBrowser.Controller.Library.ItemUpdateType.MetadataEdit, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithTagsDisabled_StillCallsUpdateToRepositoryAsync()
+    {
+        // Arrange
+        var config = new PluginConfiguration
+        {
+            EnableMovies = true,
+            EnableSeries = false,
+            AddWarningTags = false
+        };
+        _configAccessorMock.Setup(x => x.GetConfiguration()).Returns(config);
+
+        var movieMock = new Mock<Movie> { CallBase = true };
+        movieMock.Object.Name = "Test Movie";
+        movieMock.Object.Tags = Array.Empty<string>();
+        movieMock.Object.SetProviderId(MetadataProvider.Imdb, "tt2911666");
+        movieMock.Object.SetProviderId(Constants.ProviderId, "15713");
+        movieMock.Setup(x => x.UpdateToRepositoryAsync(It.IsAny<MediaBrowser.Controller.Library.ItemUpdateType>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _libraryManagerMock
+            .Setup(x => x.GetItemList(It.IsAny<InternalItemsQuery>()))
+            .Returns(new BaseItem[] { movieMock.Object });
+
+        var details = CreateMediaDetailsWithTriggers(15713, "John Wick");
+        _apiClientMock
+            .Setup(x => x.GetMediaDetailsByImdbIdAsync("tt2911666", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        // Act
+        await _task.ExecuteAsync(new Mock<IProgress<double>>().Object, CancellationToken.None);
+
+        // Assert - must persist even when tagging is disabled (DTDD provider ID still needs saving)
+        movieMock.Verify(
+            x => x.UpdateToRepositoryAsync(MediaBrowser.Controller.Library.ItemUpdateType.MetadataEdit, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ItemWithOnlyImdbId_IsProcessedOnFreshInstall()
+    {
+        // Arrange - item has IMDB ID but no DTDD ID (fresh install scenario)
+        var config = new PluginConfiguration
+        {
+            EnableMovies = true,
+            EnableSeries = false,
+            AddWarningTags = true,
+            TagPrefix = "CW:",
+            MinVotesThreshold = 0
+        };
+        _configAccessorMock.Setup(x => x.GetConfiguration()).Returns(config);
+
+        var movie = new Movie { Name = "Test Movie", Tags = Array.Empty<string>() };
+        movie.SetProviderId(MetadataProvider.Imdb, "tt2911666");
+        // No DTDD provider ID set
+
+        _libraryManagerMock
+            .Setup(x => x.GetItemList(It.IsAny<InternalItemsQuery>()))
+            .Returns(new BaseItem[] { movie });
+
+        var details = CreateMediaDetailsWithTriggers(15713, "John Wick");
+        _apiClientMock
+            .Setup(x => x.GetMediaDetailsByImdbIdAsync("tt2911666", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        // Act
+        await _task.ExecuteAsync(new Mock<IProgress<double>>().Object, CancellationToken.None);
+
+        // Assert - item should be fetched and tagged even without a pre-existing DTDD ID
+        _apiClientMock.Verify(
+            x => x.GetMediaDetailsByImdbIdAsync("tt2911666", It.IsAny<CancellationToken>()),
+            Times.Once);
+        Assert.Contains("CW: a dog dies", movie.Tags);
+    }
+
     private static Movie CreateMovie(string imdbId, string dtddId)
     {
         var movie = new Movie

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/Services/DtddLibraryScanServiceTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/Services/DtddLibraryScanServiceTests.cs
@@ -430,6 +430,43 @@ public class DtddLibraryScanServiceTests
         Assert.Contains("CW: a dog dies", movie.Tags);
     }
 
+    [Fact]
+    public void OnItemChanged_CallsUpdateToRepositoryAsync_AfterProcessing()
+    {
+        // Arrange
+        var config = new PluginConfiguration
+        {
+            EnableMovies = true,
+            AddWarningTags = true,
+            TagPrefix = "CW:",
+            MinVotesThreshold = 0
+        };
+        _configAccessorMock.Setup(x => x.GetConfiguration()).Returns(config);
+
+        var details = CreateMediaDetailsWithTriggers(15713, "John Wick");
+        _apiClientMock
+            .Setup(x => x.GetMediaDetailsByImdbIdAsync("tt2911666", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        var movieMock = new Mock<Movie> { CallBase = true };
+        movieMock.Object.Name = "Test Movie";
+        movieMock.Object.Tags = Array.Empty<string>();
+        movieMock.Object.SetProviderId(MetadataProvider.Imdb, "tt2911666");
+        movieMock.Setup(x => x.UpdateToRepositoryAsync(It.IsAny<MediaBrowser.Controller.Library.ItemUpdateType>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var eventArgs = new ItemChangeEventArgs { Item = movieMock.Object };
+
+        // Act
+        _service.OnItemChanged(null, eventArgs);
+
+        // Assert - wait for fire-and-forget async task
+        Thread.Sleep(200);
+        movieMock.Verify(
+            x => x.UpdateToRepositoryAsync(MediaBrowser.Controller.Library.ItemUpdateType.MetadataEdit, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     private static Movie CreateMovie(string imdbId)
     {
         var movie = new Movie


### PR DESCRIPTION
Tags were set on item.Tags in memory but never written back, so they were discarded when the method returned. Add UpdateToRepositoryAsync calls in both the scan service and refresh task.

Also fix GetItemsWithDtddId, which queried for items already having a Dtdd provider ID — empty on a fresh install, so the task processed zero items. Seed from items with an IMDB ID instead.

Testing: Built against Jellyfin 10.11 (net9.0) and deployed to my own server — CW tags now persist and show on library items after running the refresh task. I haven't run the unit test suite or live-tested the changed seeding query against the DTDD API directly, so a second look there is welcome.