### PR TITLE
Milestone 1: Wilson score confidence scoring for trigger filtering and tags

### DIFF
--- a/Jellyfin.Plugin.DoesTheDogDie/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/Configuration/PluginConfiguration.cs
@@ -22,6 +22,9 @@ public class PluginConfiguration : BasePluginConfiguration
         TagPrefix = "CW:";
         SafeTagPrefix = "Safe:";
         RefreshIntervalHours = 24;
+        UseConfidenceScoring = false;
+        MinConfidenceThreshold = 0.7;
+        ShowConfidenceInTags = false;
         ShowAllTriggers = true;
         EnabledCategoryIds = new List<int>();
         EnabledTopicIds = new List<int>();
@@ -71,6 +74,25 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets the refresh interval in hours for the scheduled task.
     /// </summary>
     public int RefreshIntervalHours { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to filter triggers using
+    /// statistical confidence (Wilson score) instead of raw vote counts alone.
+    /// When false, only <see cref="MinVotesThreshold"/> applies.
+    /// </summary>
+    public bool UseConfidenceScoring { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimum confidence (0.0-1.0) required to include a
+    /// trigger when <see cref="UseConfidenceScoring"/> is enabled.
+    /// </summary>
+    public double MinConfidenceThreshold { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to append the confidence
+    /// percentage to tag names, e.g. "CW: a dog dies (95%)".
+    /// </summary>
+    public bool ShowConfidenceInTags { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether to include all triggers.

--- a/Jellyfin.Plugin.DoesTheDogDie/Configuration/configPage.html
+++ b/Jellyfin.Plugin.DoesTheDogDie/Configuration/configPage.html
@@ -136,6 +136,25 @@
                             <input id="MinVotesThreshold" name="MinVotesThreshold" type="number" is="emby-input" min="1" max="100" />
                             <div class="fieldDescription">Minimum votes required before showing a tag</div>
                         </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="UseConfidenceScoring" name="UseConfidenceScoring" type="checkbox" is="emby-checkbox" />
+                                <span>Use statistical confidence scoring</span>
+                            </label>
+                            <div class="fieldDescription">Filter triggers using a Wilson score confidence interval instead of raw vote counts alone. Triggers with few or conflicting votes are excluded.</div>
+                        </div>
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="MinConfidenceThreshold">Minimum Confidence</label>
+                            <input id="MinConfidenceThreshold" name="MinConfidenceThreshold" type="number" is="emby-input" min="0" max="1" step="0.05" />
+                            <div class="fieldDescription">Confidence (0.0&ndash;1.0) required to show a trigger when confidence scoring is enabled (default 0.7)</div>
+                        </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="ShowConfidenceInTags" name="ShowConfidenceInTags" type="checkbox" is="emby-checkbox" />
+                                <span>Show confidence percentage in tags</span>
+                            </label>
+                            <div class="fieldDescription">Append confidence to tag names, e.g. "CW: a dog dies (95%)"</div>
+                        </div>
                     </div>
 
                     <!-- Trigger Filtering Section -->
@@ -222,6 +241,9 @@
                     document.querySelector('#TagPrefix').value = config.TagPrefix ?? config.tagPrefix ?? 'CW:';
                     document.querySelector('#SafeTagPrefix').value = config.SafeTagPrefix ?? config.safeTagPrefix ?? 'Safe:';
                     document.querySelector('#MinVotesThreshold').value = config.MinVotesThreshold ?? config.minVotesThreshold ?? 3;
+                    document.querySelector('#UseConfidenceScoring').checked = config.UseConfidenceScoring ?? config.useConfidenceScoring ?? false;
+                    document.querySelector('#MinConfidenceThreshold').value = config.MinConfidenceThreshold ?? config.minConfidenceThreshold ?? 0.7;
+                    document.querySelector('#ShowConfidenceInTags').checked = config.ShowConfidenceInTags ?? config.showConfidenceInTags ?? false;
 
                     // Trigger filtering (check both casings)
                     document.querySelector('#ShowAllTriggers').checked = config.ShowAllTriggers ?? config.showAllTriggers ?? true;
@@ -480,6 +502,9 @@
                         config.TagPrefix = document.querySelector('#TagPrefix').value;
                         config.SafeTagPrefix = document.querySelector('#SafeTagPrefix').value;
                         config.MinVotesThreshold = parseInt(document.querySelector('#MinVotesThreshold').value) || 3;
+                        config.UseConfidenceScoring = document.querySelector('#UseConfidenceScoring').checked;
+                        config.MinConfidenceThreshold = parseFloat(document.querySelector('#MinConfidenceThreshold').value) || 0.7;
+                        config.ShowConfidenceInTags = document.querySelector('#ShowConfidenceInTags').checked;
 
                         // Trigger filtering
                         config.ShowAllTriggers = document.querySelector('#ShowAllTriggers').checked;

--- a/Jellyfin.Plugin.DoesTheDogDie/Providers/DtddEpisodeProvider.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/Providers/DtddEpisodeProvider.cs
@@ -117,7 +117,7 @@ public class DtddEpisodeProvider : ICustomMetadataProvider<Episode>, IHasOrder
                 continue;
             }
 
-            var tagName = $"{config.TagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.TagPrefix, trigger, config)!;
 
             if (!item.Tags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {

--- a/Jellyfin.Plugin.DoesTheDogDie/Providers/DtddMovieProvider.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/Providers/DtddMovieProvider.cs
@@ -135,7 +135,7 @@ public class DtddMovieProvider : ICustomMetadataProvider<Movie>, IHasOrder
                 continue;
             }
 
-            var tagName = $"{config.TagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.TagPrefix, trigger, config)!;
             if (!existingTags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {
                 existingTags.Add(tagName);
@@ -154,7 +154,7 @@ public class DtddMovieProvider : ICustomMetadataProvider<Movie>, IHasOrder
                 continue;
             }
 
-            var tagName = $"{config.SafeTagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.SafeTagPrefix, trigger, config)!;
             if (!existingTags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {
                 existingTags.Add(tagName);

--- a/Jellyfin.Plugin.DoesTheDogDie/Providers/DtddSeasonProvider.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/Providers/DtddSeasonProvider.cs
@@ -117,7 +117,7 @@ public class DtddSeasonProvider : ICustomMetadataProvider<Season>, IHasOrder
                 continue;
             }
 
-            var tagName = $"{config.TagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.TagPrefix, trigger, config)!;
 
             if (!item.Tags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {

--- a/Jellyfin.Plugin.DoesTheDogDie/Providers/DtddSeriesProvider.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/Providers/DtddSeriesProvider.cs
@@ -131,7 +131,7 @@ public class DtddSeriesProvider : ICustomMetadataProvider<Series>, IHasOrder
                 continue;
             }
 
-            var tagName = $"{config.TagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.TagPrefix, trigger, config)!;
             if (!existingTags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {
                 existingTags.Add(tagName);
@@ -150,7 +150,7 @@ public class DtddSeriesProvider : ICustomMetadataProvider<Series>, IHasOrder
                 continue;
             }
 
-            var tagName = $"{config.SafeTagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.SafeTagPrefix, trigger, config)!;
             if (!existingTags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {
                 existingTags.Add(tagName);

--- a/Jellyfin.Plugin.DoesTheDogDie/ScheduledTasks/DtddRefreshTask.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/ScheduledTasks/DtddRefreshTask.cs
@@ -242,7 +242,7 @@ public class DtddRefreshTask : IScheduledTask
                 continue;
             }
 
-            var tagName = $"{config.TagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.TagPrefix, trigger, config)!;
             if (!existingTags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {
                 existingTags.Add(tagName);
@@ -261,7 +261,7 @@ public class DtddRefreshTask : IScheduledTask
                 continue;
             }
 
-            var tagName = $"{config.SafeTagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.SafeTagPrefix, trigger, config)!;
             if (!existingTags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {
                 existingTags.Add(tagName);

--- a/Jellyfin.Plugin.DoesTheDogDie/Scoring/BetaConfidenceCalculator.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/Scoring/BetaConfidenceCalculator.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Jellyfin.Plugin.DoesTheDogDie.Scoring;
+
+/// <summary>
+/// Calculates statistical confidence that a trigger applies using the
+/// Wilson score interval lower bound.
+/// </summary>
+public static class BetaConfidenceCalculator
+{
+    /// <summary>
+    /// Z-score for a 95% confidence interval.
+    /// </summary>
+    private const double Z = 1.96;
+
+    /// <summary>
+    /// Calculates the lower bound of the 95% Wilson score confidence interval
+    /// for the proportion of positive votes.
+    /// </summary>
+    /// <param name="positiveVotes">Number of votes agreeing the trigger applies.</param>
+    /// <param name="totalVotes">Total number of votes cast.</param>
+    /// <returns>Confidence score between 0.0 and 1.0.</returns>
+    public static double CalculateConfidence(int positiveVotes, int totalVotes)
+    {
+        if (totalVotes <= 0 || positiveVotes <= 0)
+        {
+            return 0.0;
+        }
+
+        var n = (double)totalVotes;
+        var p = Math.Min(positiveVotes, totalVotes) / n;
+        var zSquared = Z * Z;
+
+        var numerator = p + (zSquared / (2 * n))
+            - (Z * Math.Sqrt(((p * (1 - p)) + (zSquared / (4 * n))) / n));
+        var lowerBound = numerator / (1 + (zSquared / n));
+
+        return Math.Clamp(lowerBound, 0.0, 1.0);
+    }
+}

--- a/Jellyfin.Plugin.DoesTheDogDie/Services/DtddLibraryScanService.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/Services/DtddLibraryScanService.cs
@@ -170,7 +170,7 @@ public class DtddLibraryScanService : IHostedService
                 continue;
             }
 
-            var tagName = $"{config.TagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.TagPrefix, trigger, config)!;
             if (!existingTags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {
                 existingTags.Add(tagName);
@@ -189,7 +189,7 @@ public class DtddLibraryScanService : IHostedService
                 continue;
             }
 
-            var tagName = $"{config.SafeTagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.SafeTagPrefix, trigger, config)!;
             if (!existingTags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {
                 existingTags.Add(tagName);

--- a/Jellyfin.Plugin.DoesTheDogDie/TriggerFilter.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/TriggerFilter.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.DoesTheDogDie.Api.Models;
 using Jellyfin.Plugin.DoesTheDogDie.Configuration;
+using Jellyfin.Plugin.DoesTheDogDie.Scoring;
 
 namespace Jellyfin.Plugin.DoesTheDogDie;
 
@@ -17,6 +19,12 @@ public static class TriggerFilter
     /// <returns>True if the trigger should be included, false otherwise.</returns>
     public static bool ShouldIncludeTrigger(DtddTopicItemStat trigger, PluginConfiguration config)
     {
+        // Statistical confidence filter applies regardless of category selection
+        if (config.UseConfidenceScoring && GetConfidence(trigger) < config.MinConfidenceThreshold)
+        {
+            return false;
+        }
+
         // Master switch - include everything
         if (config.ShowAllTriggers)
         {
@@ -56,6 +64,18 @@ public static class TriggerFilter
 
         // Otherwise, topic must be explicitly enabled
         return config.EnabledTopicIds.Contains(topic.Id);
+    }
+
+    /// <summary>
+    /// Calculates the statistical confidence that a trigger's majority vote
+    /// direction is correct, using the Wilson score interval lower bound.
+    /// </summary>
+    /// <param name="trigger">The trigger to evaluate.</param>
+    /// <returns>Confidence score between 0.0 and 1.0.</returns>
+    public static double GetConfidence(DtddTopicItemStat trigger)
+    {
+        var majorityVotes = Math.Max(trigger.YesSum, trigger.NoSum);
+        return BetaConfidenceCalculator.CalculateConfidence(majorityVotes, trigger.TotalVotes);
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.DoesTheDogDie/TriggerTagFormatter.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/TriggerTagFormatter.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Globalization;
+using Jellyfin.Plugin.DoesTheDogDie.Api.Models;
+using Jellyfin.Plugin.DoesTheDogDie.Configuration;
+
+namespace Jellyfin.Plugin.DoesTheDogDie;
+
+/// <summary>
+/// Helper class for building tag names from triggers.
+/// </summary>
+public static class TriggerTagFormatter
+{
+    /// <summary>
+    /// Builds the tag name for a trigger, optionally appending the confidence
+    /// percentage (rounded to the nearest 5%) when enabled in configuration.
+    /// </summary>
+    /// <param name="prefix">The tag prefix (e.g. "CW:" or "Safe:").</param>
+    /// <param name="trigger">The trigger to format.</param>
+    /// <param name="config">The plugin configuration.</param>
+    /// <returns>The formatted tag name, or null if the trigger has no topic.</returns>
+    public static string? FormatTagName(string prefix, DtddTopicItemStat trigger, PluginConfiguration config)
+    {
+        if (trigger.Topic == null)
+        {
+            return null;
+        }
+
+        var tagName = $"{prefix} {trigger.Topic.Name}";
+
+        if (config.ShowConfidenceInTags)
+        {
+            var confidence = TriggerFilter.GetConfidence(trigger);
+            var percent = (int)(Math.Round(confidence * 100 / 5.0) * 5);
+            tagName += string.Create(CultureInfo.InvariantCulture, $" ({percent}%)");
+        }
+
+        return tagName;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Copy the contents of `Jellyfin.Plugin.DoesTheDogDie/bin/Release/net9.0/publish/`
 | Tag Prefix | Customize warning tag prefix | `CW:` |
 | Safe Tag Prefix | Customize safe tag prefix | `Safe:` |
 | Min Votes Threshold | Minimum votes required to show a trigger | `3` |
+| Use Confidence Scoring | Filter triggers by Wilson score confidence instead of raw vote counts alone | `false` |
+| Min Confidence Threshold | Confidence (0.0–1.0) required to show a trigger when confidence scoring is enabled | `0.7` |
+| Show Confidence In Tags | Append confidence to tag names, e.g. `CW: a dog dies (95%)` | `false` |
 | Trigger Categories | Select which categories to track (Animal, Violence, etc.) | All |
 
 ## Requirements

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Does The Dog Die"
 guid: "eb5d7894-8eef-4b36-aa6f-5d124e828ce1"
-version: "0.1.0.0"
+version: "0.1.1.0"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Display content warnings from DoesTheDogDie.com"
@@ -15,9 +15,8 @@ owner: "theflanman"
 artifacts:
 - "Jellyfin.Plugin.DoesTheDogDie.dll"
 changelog: |
-  - Initial release with DoesTheDogDie.com integration
-  - Hierarchical trigger filtering (categories and topics)
-  - Content warning tags (CW:) and safe tags (Safe:)
-  - Background service for automatic lookups
-  - Scheduled task for periodic refresh
-  - External ID and URL providers
+  - Statistical confidence scoring (Wilson score interval) for trigger filtering
+  - Optional confidence percentage in tag names, e.g. "CW: a dog dies (95%)"
+  - New settings: UseConfidenceScoring, MinConfidenceThreshold, ShowConfidenceInTags
+  - Fix: tags now persist to the library from scan service and refresh task
+  - Fix: refresh task seeds items without a DTDD id on fresh installs

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/ConfigPersistenceTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/ConfigPersistenceTests.cs
@@ -148,6 +148,14 @@ public sealed class ConfigPersistenceTests
         {
             await ResetConfigAsync();
             await _fixture.Client.RefreshItemMetadataAsync(johnWick.Id, replaceAllMetadata: true);
+            await TestHelpers.WaitForAsync(
+                async () =>
+                {
+                    var refreshed = (await _fixture.Client.GetItemsAsync("Movie")).Single(m => m.Name == "John Wick");
+                    return refreshed.Tags.Contains("CW: an animal dies");
+                },
+                System.TimeSpan.FromSeconds(30),
+                failureMessage: "Cleanup: tags did not return after restoring default config");
         }
     }
 

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/DescriptionInjectionContentTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/DescriptionInjectionContentTests.cs
@@ -178,11 +178,15 @@ public sealed class DescriptionInjectionContentTests
             async () =>
             {
                 var refreshed = (await _fixture.Client.GetItemsAsync("Movie")).Single(m => m.Name == "John Wick");
-                return refreshed.Overview is null
-                    || !refreshed.Overview.Contains(DtddStartMarker, StringComparison.Ordinal);
+
+                // Tags must be restored too: the test body may have raised MinVotesThreshold,
+                // stripping CW: tags; later tests rely on the default-config tag state.
+                return (refreshed.Overview is null
+                    || !refreshed.Overview.Contains(DtddStartMarker, StringComparison.Ordinal))
+                    && refreshed.Tags.Contains("CW: an animal dies");
             },
             TimeSpan.FromSeconds(30),
-            failureMessage: "Cleanup: DTDD markers should be removed after disabling AddDescriptionWarnings");
+            failureMessage: "Cleanup: DTDD markers should be removed and CW: tags restored after resetting config");
     }
 
     private async Task<JellyfinClient.JellyfinItemDto> WaitForInjectedAsync()

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/Providers/DtddMovieProviderTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/Providers/DtddMovieProviderTests.cs
@@ -280,6 +280,35 @@ public class DtddMovieProviderTests
     }
 
     [Fact]
+    public async Task FetchAsync_ShowConfidenceInTags_AppendsConfidencePercentage()
+    {
+        // Arrange
+        SetupConfiguration(new PluginConfiguration
+        {
+            EnableMovies = true,
+            AddWarningTags = true,
+            TagPrefix = "CW:",
+            MinVotesThreshold = 0,
+            ShowConfidenceInTags = true
+        });
+        var movie = CreateMovie("tt2911666");
+
+        var details = CreateMediaDetailsWithTriggers(15713, "John Wick");
+        _apiClientMock
+            .Setup(x => x.GetMediaDetailsByImdbIdAsync("tt2911666", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        // Act
+        var result = await _provider.FetchAsync(movie, _defaultOptions, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(ItemUpdateType.MetadataDownload, result);
+
+        // "a dog dies" has 1336 yes / 118 no => Wilson confidence 0.904 => 90%
+        Assert.Contains("CW: a dog dies (90%)", movie.Tags);
+    }
+
+    [Fact]
     public async Task FetchAsync_MinVotesThreshold_FiltersTriggers()
     {
         // Arrange

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/Scoring/BetaConfidenceCalculatorTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/Scoring/BetaConfidenceCalculatorTests.cs
@@ -1,0 +1,96 @@
+using Jellyfin.Plugin.DoesTheDogDie.Scoring;
+using Xunit;
+
+namespace Jellyfin.Plugin.DoesTheDogDie.Tests.Scoring;
+
+public class BetaConfidenceCalculatorTests
+{
+    [Fact]
+    public void CalculateConfidence_ZeroVotes_ReturnsZero()
+    {
+        // Act
+        var result = BetaConfidenceCalculator.CalculateConfidence(0, 0);
+
+        // Assert
+        Assert.Equal(0.0, result);
+    }
+
+    [Fact]
+    public void CalculateConfidence_ZeroPositiveVotes_ReturnsZero()
+    {
+        // Act
+        var result = BetaConfidenceCalculator.CalculateConfidence(0, 10);
+
+        // Assert
+        Assert.Equal(0.0, result);
+    }
+
+    [Theory]
+    [InlineData(1, 1, 0.206543)] // Single unanimous vote - low confidence
+    [InlineData(10, 10, 0.722460)] // 10 unanimous votes - high confidence
+    [InlineData(100, 100, 0.963005)] // 100 unanimous votes - very high confidence
+    [InlineData(50, 100, 0.403830)] // Equal split - below 50%
+    [InlineData(3, 3, 0.438494)] // Default vote threshold, unanimous
+    [InlineData(75, 100, 0.656954)] // 75% agreement with good sample size
+    [InlineData(1336, 1454, 0.903680)] // Real-world example from DTDD
+    public void CalculateConfidence_KnownValues_ReturnsWilsonLowerBound(
+        int positiveVotes,
+        int totalVotes,
+        double expected)
+    {
+        // Act
+        var result = BetaConfidenceCalculator.CalculateConfidence(positiveVotes, totalVotes);
+
+        // Assert
+        Assert.Equal(expected, result, precision: 6);
+    }
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(5, 10)]
+    [InlineData(1000, 1000)]
+    public void CalculateConfidence_AnyInput_ReturnsValueBetweenZeroAndOne(
+        int positiveVotes,
+        int totalVotes)
+    {
+        // Act
+        var result = BetaConfidenceCalculator.CalculateConfidence(positiveVotes, totalVotes);
+
+        // Assert
+        Assert.InRange(result, 0.0, 1.0);
+    }
+
+    [Fact]
+    public void CalculateConfidence_MoreVotesSameRatio_IncreasesConfidence()
+    {
+        // Arrange - same 100% yes ratio with increasing sample sizes
+        var lowSample = BetaConfidenceCalculator.CalculateConfidence(2, 2);
+        var midSample = BetaConfidenceCalculator.CalculateConfidence(20, 20);
+        var highSample = BetaConfidenceCalculator.CalculateConfidence(200, 200);
+
+        // Assert
+        Assert.True(lowSample < midSample);
+        Assert.True(midSample < highSample);
+    }
+
+    [Fact]
+    public void CalculateConfidence_NegativeVotes_ReturnsZero()
+    {
+        // Act
+        var result = BetaConfidenceCalculator.CalculateConfidence(-1, 10);
+
+        // Assert
+        Assert.Equal(0.0, result);
+    }
+
+    [Fact]
+    public void CalculateConfidence_PositiveExceedsTotal_ClampsToTotal()
+    {
+        // Arrange - defensive: malformed data where yes > total
+        var clamped = BetaConfidenceCalculator.CalculateConfidence(15, 10);
+        var unanimous = BetaConfidenceCalculator.CalculateConfidence(10, 10);
+
+        // Assert
+        Assert.Equal(unanimous, clamped, precision: 6);
+    }
+}

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/TriggerFilterTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/TriggerFilterTests.cs
@@ -261,13 +261,165 @@ public class TriggerFilterTests
         Assert.Equal("a dog dies", result[0].Topic?.Name);
     }
 
-    private static DtddTopicItemStat CreateTrigger(int categoryId, int topicId, string name = "test trigger")
+    [Fact]
+    public void PluginConfiguration_ConfidenceDefaults_AreBackwardCompatible()
+    {
+        // Arrange / Act
+        var config = new PluginConfiguration();
+
+        // Assert
+        Assert.False(config.UseConfidenceScoring);
+        Assert.Equal(0.7, config.MinConfidenceThreshold);
+    }
+
+    [Fact]
+    public void ShouldIncludeTrigger_ConfidenceScoringDisabled_IgnoresConfidence()
+    {
+        // Arrange - 1 yes / 0 no has Wilson confidence ~0.21, well below threshold
+        var config = new PluginConfiguration
+        {
+            ShowAllTriggers = true,
+            UseConfidenceScoring = false,
+            MinConfidenceThreshold = 0.7
+        };
+        var trigger = CreateTrigger(categoryId: 2, topicId: 153, yesSum: 1, noSum: 0);
+
+        // Act
+        var result = TriggerFilter.ShouldIncludeTrigger(trigger, config);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldIncludeTrigger_ConfidenceAboveThreshold_ReturnsTrue()
+    {
+        // Arrange - 100 yes / 0 no has Wilson confidence ~0.96
+        var config = new PluginConfiguration
+        {
+            ShowAllTriggers = true,
+            UseConfidenceScoring = true,
+            MinConfidenceThreshold = 0.7
+        };
+        var trigger = CreateTrigger(categoryId: 2, topicId: 153, yesSum: 100, noSum: 0);
+
+        // Act
+        var result = TriggerFilter.ShouldIncludeTrigger(trigger, config);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldIncludeTrigger_ConfidenceBelowThreshold_ReturnsFalse()
+    {
+        // Arrange - 3 yes / 0 no has Wilson confidence ~0.44
+        var config = new PluginConfiguration
+        {
+            ShowAllTriggers = true,
+            UseConfidenceScoring = true,
+            MinConfidenceThreshold = 0.7
+        };
+        var trigger = CreateTrigger(categoryId: 2, topicId: 153, yesSum: 3, noSum: 0);
+
+        // Act
+        var result = TriggerFilter.ShouldIncludeTrigger(trigger, config);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ShouldIncludeTrigger_NegativeTriggerHighConfidence_ReturnsTrue()
+    {
+        // Arrange - 0 yes / 100 no: confidence is measured on the majority
+        // (safe) direction, so this should pass the threshold
+        var config = new PluginConfiguration
+        {
+            ShowAllTriggers = true,
+            UseConfidenceScoring = true,
+            MinConfidenceThreshold = 0.7
+        };
+        var trigger = CreateTrigger(categoryId: 2, topicId: 153, yesSum: 0, noSum: 100);
+
+        // Act
+        var result = TriggerFilter.ShouldIncludeTrigger(trigger, config);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldIncludeTrigger_ConfidenceScoringEnabled_CategoryFilterStillApplies()
+    {
+        // Arrange - high confidence but category not enabled
+        var config = new PluginConfiguration
+        {
+            ShowAllTriggers = false,
+            EnabledCategoryIds = new List<int> { 3 },
+            UseConfidenceScoring = true,
+            MinConfidenceThreshold = 0.7
+        };
+        var trigger = CreateTrigger(categoryId: 2, topicId: 153, yesSum: 100, noSum: 0);
+
+        // Act
+        var result = TriggerFilter.ShouldIncludeTrigger(trigger, config);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void GetConfidence_ReturnsWilsonScoreOfMajorityDirection()
+    {
+        // Arrange
+        var positive = CreateTrigger(categoryId: 2, topicId: 153, yesSum: 100, noSum: 0);
+        var negative = CreateTrigger(categoryId: 2, topicId: 153, yesSum: 0, noSum: 100);
+
+        // Act / Assert - both unanimous with 100 votes => ~0.963
+        Assert.Equal(0.963005, TriggerFilter.GetConfidence(positive), precision: 6);
+        Assert.Equal(0.963005, TriggerFilter.GetConfidence(negative), precision: 6);
+    }
+
+    [Fact]
+    public void FilterTriggers_ConfidenceScoringEnabled_FiltersLowConfidence()
+    {
+        // Arrange
+        var config = new PluginConfiguration
+        {
+            ShowAllTriggers = true,
+            UseConfidenceScoring = true,
+            MinConfidenceThreshold = 0.7
+        };
+
+        var triggers = new List<DtddTopicItemStat>
+        {
+            CreateTrigger(categoryId: 2, topicId: 153, name: "a dog dies", yesSum: 100, noSum: 0),
+            CreateTrigger(categoryId: 2, topicId: 154, name: "a cat dies", yesSum: 2, noSum: 1),
+            CreateTrigger(categoryId: 2, topicId: 155, name: "a horse dies", yesSum: 50, noSum: 2)
+        };
+
+        // Act
+        var filtered = TriggerFilter.FilterTriggers(triggers, config);
+
+        // Assert
+        var result = new List<DtddTopicItemStat>(filtered);
+        Assert.Equal(2, result.Count);
+        Assert.DoesNotContain(result, t => t.Topic?.Name == "a cat dies");
+    }
+
+    private static DtddTopicItemStat CreateTrigger(
+        int categoryId,
+        int topicId,
+        string name = "test trigger",
+        int yesSum = 100,
+        int noSum = 10)
     {
         return new DtddTopicItemStat
         {
             TopicItemId = topicId * 100,
-            YesSum = 100,
-            NoSum = 10,
+            YesSum = yesSum,
+            NoSum = noSum,
             TopicId = topicId,
             Topic = new DtddTopic
             {

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/TriggerTagFormatterTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/TriggerTagFormatterTests.cs
@@ -1,0 +1,104 @@
+using Jellyfin.Plugin.DoesTheDogDie.Api.Models;
+using Jellyfin.Plugin.DoesTheDogDie.Configuration;
+using Xunit;
+
+namespace Jellyfin.Plugin.DoesTheDogDie.Tests;
+
+public class TriggerTagFormatterTests
+{
+    [Fact]
+    public void PluginConfiguration_ShowConfidenceInTags_DefaultsToFalse()
+    {
+        // Arrange / Act
+        var config = new PluginConfiguration();
+
+        // Assert
+        Assert.False(config.ShowConfidenceInTags);
+    }
+
+    [Fact]
+    public void FormatTagName_ConfidenceDisabled_ReturnsPlainTag()
+    {
+        // Arrange
+        var config = new PluginConfiguration { ShowConfidenceInTags = false };
+        var trigger = CreateTrigger("a dog dies", yesSum: 100, noSum: 0);
+
+        // Act
+        var result = TriggerTagFormatter.FormatTagName("CW:", trigger, config);
+
+        // Assert
+        Assert.Equal("CW: a dog dies", result);
+    }
+
+    [Fact]
+    public void FormatTagName_ConfidenceEnabled_AppendsPercentage()
+    {
+        // Arrange - 100 yes / 0 no => Wilson confidence 0.963 => 96.3% => 95%
+        var config = new PluginConfiguration { ShowConfidenceInTags = true };
+        var trigger = CreateTrigger("a dog dies", yesSum: 100, noSum: 0);
+
+        // Act
+        var result = TriggerTagFormatter.FormatTagName("CW:", trigger, config);
+
+        // Assert
+        Assert.Equal("CW: a dog dies (95%)", result);
+    }
+
+    [Theory]
+    [InlineData(10, 0, "70%")] // 0.722460 => 72.2% => 70%
+    [InlineData(1336, 118, "90%")] // 0.903680 => 90.4% => 90%
+    [InlineData(1, 0, "20%")] // 0.206543 => 20.7% => 20%
+    public void FormatTagName_ConfidenceEnabled_RoundsToNearestFivePercent(
+        int yesSum,
+        int noSum,
+        string expectedPercent)
+    {
+        // Arrange
+        var config = new PluginConfiguration { ShowConfidenceInTags = true };
+        var trigger = CreateTrigger("a dog dies", yesSum, noSum);
+
+        // Act
+        var result = TriggerTagFormatter.FormatTagName("CW:", trigger, config);
+
+        // Assert
+        Assert.Equal($"CW: a dog dies ({expectedPercent})", result);
+    }
+
+    [Fact]
+    public void FormatTagName_NegativeTrigger_UsesMajorityDirectionConfidence()
+    {
+        // Arrange - 0 yes / 100 no: safe confirmation with confidence 0.963 => 95%
+        var config = new PluginConfiguration { ShowConfidenceInTags = true };
+        var trigger = CreateTrigger("a cat dies", yesSum: 0, noSum: 100);
+
+        // Act
+        var result = TriggerTagFormatter.FormatTagName("Safe:", trigger, config);
+
+        // Assert
+        Assert.Equal("Safe: a cat dies (95%)", result);
+    }
+
+    [Fact]
+    public void FormatTagName_NullTopic_ReturnsNull()
+    {
+        // Arrange
+        var config = new PluginConfiguration();
+        var trigger = new DtddTopicItemStat { Topic = null };
+
+        // Act
+        var result = TriggerTagFormatter.FormatTagName("CW:", trigger, config);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    private static DtddTopicItemStat CreateTrigger(string name, int yesSum, int noSum)
+    {
+        return new DtddTopicItemStat
+        {
+            YesSum = yesSum,
+            NoSum = noSum,
+            Topic = new DtddTopic { Id = 153, Name = name }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Milestone 1: Beta Distribution Confidence Rating** — replaces the simple vote threshold with a statistically sound confidence calculation.

- **#1 — Wilson score calculator:** new `Scoring/BetaConfidenceCalculator` computes the lower bound of the 95% Wilson score confidence interval (z=1.96), returning 0.0–1.0 with edge cases handled (0 votes, negative input, yes > total).
- **#2 — Confidence-based filtering:** new `UseConfidenceScoring` (default `false`) and `MinConfidenceThreshold` (default `0.7`) config options. `TriggerFilter` drops triggers whose majority-direction confidence falls below the threshold. Defaults preserve existing behavior (`MinVotesThreshold` untouched).
- **#3 — Confidence in tags:** new `ShowConfidenceInTags` option formats tags as `CW: a dog dies (95%)`, rounded to the nearest 5%. Tag construction is centralized in a shared `TriggerTagFormatter` used by all four providers, the library scan service, and the refresh task.
- Config page exposes all three options.
- Version bumped to 0.1.1.0 in build.yaml with updated changelog.

## Test plan

- 30 new unit tests (TDD: calculator reference values verified independently, filter behavior, tag formatting, provider integration). Total: **219 unit tests, all passing**.
- **E2E suite: 25 passed / 0 failed** (6 pre-existing intentional skips).
- Also fixes a pre-existing E2E test-pollution failure on `development`: `DescriptionInjectionContentTests` cleanup waited only for overview markers (which never exist while description-injection is unmerged) and returned before its restore-refresh re-added CW: tags, so `MovieMetadataTests.JohnWick_GetsCwTagsForPositiveTriggers` read a tagless item. Cleanup now also waits for tags to be restored (same hardening applied to `ConfigPersistenceTests`).

Closes #1
Closes #2
Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)