### PR TITLE
Release 0.1.1.0: Milestone 1 — confidence scoring, tag persistence fixes, E2E suite

### DIFF
--- a/Jellyfin.Plugin.DoesTheDogDie.sln
+++ b/Jellyfin.Plugin.DoesTheDogDie.sln
@@ -1,10 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# 
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.DoesTheDogDie", "Jellyfin.Plugin.DoesTheDogDie\Jellyfin.Plugin.DoesTheDogDie.csproj", "{D921B930-CF91-406F-ACBC-08914DCD0D34}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.DoesTheDogDie.Tests", "tests\Jellyfin.Plugin.DoesTheDogDie.Tests\Jellyfin.Plugin.DoesTheDogDie.Tests.csproj", "{DA1F146D-2CC1-42D3-8DC6-060F95D46FDB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.DoesTheDogDie.E2ETests", "tests\Jellyfin.Plugin.DoesTheDogDie.E2ETests\Jellyfin.Plugin.DoesTheDogDie.E2ETests.csproj", "{6314320E-F56B-4002-935D-6385AC263739}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -40,11 +43,24 @@ Global
 		{DA1F146D-2CC1-42D3-8DC6-060F95D46FDB}.Release|x64.Build.0 = Release|Any CPU
 		{DA1F146D-2CC1-42D3-8DC6-060F95D46FDB}.Release|x86.ActiveCfg = Release|Any CPU
 		{DA1F146D-2CC1-42D3-8DC6-060F95D46FDB}.Release|x86.Build.0 = Release|Any CPU
+		{6314320E-F56B-4002-935D-6385AC263739}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6314320E-F56B-4002-935D-6385AC263739}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6314320E-F56B-4002-935D-6385AC263739}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6314320E-F56B-4002-935D-6385AC263739}.Debug|x64.Build.0 = Debug|Any CPU
+		{6314320E-F56B-4002-935D-6385AC263739}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6314320E-F56B-4002-935D-6385AC263739}.Debug|x86.Build.0 = Debug|Any CPU
+		{6314320E-F56B-4002-935D-6385AC263739}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6314320E-F56B-4002-935D-6385AC263739}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6314320E-F56B-4002-935D-6385AC263739}.Release|x64.ActiveCfg = Release|Any CPU
+		{6314320E-F56B-4002-935D-6385AC263739}.Release|x64.Build.0 = Release|Any CPU
+		{6314320E-F56B-4002-935D-6385AC263739}.Release|x86.ActiveCfg = Release|Any CPU
+		{6314320E-F56B-4002-935D-6385AC263739}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{DA1F146D-2CC1-42D3-8DC6-060F95D46FDB} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{6314320E-F56B-4002-935D-6385AC263739} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/Jellyfin.Plugin.DoesTheDogDie/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/Configuration/PluginConfiguration.cs
@@ -22,6 +22,9 @@ public class PluginConfiguration : BasePluginConfiguration
         TagPrefix = "CW:";
         SafeTagPrefix = "Safe:";
         RefreshIntervalHours = 24;
+        UseConfidenceScoring = false;
+        MinConfidenceThreshold = 0.7;
+        ShowConfidenceInTags = false;
         ShowAllTriggers = true;
         EnabledCategoryIds = new List<int>();
         EnabledTopicIds = new List<int>();
@@ -71,6 +74,25 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets the refresh interval in hours for the scheduled task.
     /// </summary>
     public int RefreshIntervalHours { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to filter triggers using
+    /// statistical confidence (Wilson score) instead of raw vote counts alone.
+    /// When false, only <see cref="MinVotesThreshold"/> applies.
+    /// </summary>
+    public bool UseConfidenceScoring { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimum confidence (0.0-1.0) required to include a
+    /// trigger when <see cref="UseConfidenceScoring"/> is enabled.
+    /// </summary>
+    public double MinConfidenceThreshold { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to append the confidence
+    /// percentage to tag names, e.g. "CW: a dog dies (95%)".
+    /// </summary>
+    public bool ShowConfidenceInTags { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether to include all triggers.

--- a/Jellyfin.Plugin.DoesTheDogDie/Configuration/configPage.html
+++ b/Jellyfin.Plugin.DoesTheDogDie/Configuration/configPage.html
@@ -136,6 +136,25 @@
                             <input id="MinVotesThreshold" name="MinVotesThreshold" type="number" is="emby-input" min="1" max="100" />
                             <div class="fieldDescription">Minimum votes required before showing a tag</div>
                         </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="UseConfidenceScoring" name="UseConfidenceScoring" type="checkbox" is="emby-checkbox" />
+                                <span>Use statistical confidence scoring</span>
+                            </label>
+                            <div class="fieldDescription">Filter triggers using a Wilson score confidence interval instead of raw vote counts alone. Triggers with few or conflicting votes are excluded.</div>
+                        </div>
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="MinConfidenceThreshold">Minimum Confidence</label>
+                            <input id="MinConfidenceThreshold" name="MinConfidenceThreshold" type="number" is="emby-input" min="0" max="1" step="0.05" />
+                            <div class="fieldDescription">Confidence (0.0&ndash;1.0) required to show a trigger when confidence scoring is enabled (default 0.7)</div>
+                        </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="ShowConfidenceInTags" name="ShowConfidenceInTags" type="checkbox" is="emby-checkbox" />
+                                <span>Show confidence percentage in tags</span>
+                            </label>
+                            <div class="fieldDescription">Append confidence to tag names, e.g. "CW: a dog dies (95%)"</div>
+                        </div>
                     </div>
 
                     <!-- Trigger Filtering Section -->
@@ -222,6 +241,9 @@
                     document.querySelector('#TagPrefix').value = config.TagPrefix ?? config.tagPrefix ?? 'CW:';
                     document.querySelector('#SafeTagPrefix').value = config.SafeTagPrefix ?? config.safeTagPrefix ?? 'Safe:';
                     document.querySelector('#MinVotesThreshold').value = config.MinVotesThreshold ?? config.minVotesThreshold ?? 3;
+                    document.querySelector('#UseConfidenceScoring').checked = config.UseConfidenceScoring ?? config.useConfidenceScoring ?? false;
+                    document.querySelector('#MinConfidenceThreshold').value = config.MinConfidenceThreshold ?? config.minConfidenceThreshold ?? 0.7;
+                    document.querySelector('#ShowConfidenceInTags').checked = config.ShowConfidenceInTags ?? config.showConfidenceInTags ?? false;
 
                     // Trigger filtering (check both casings)
                     document.querySelector('#ShowAllTriggers').checked = config.ShowAllTriggers ?? config.showAllTriggers ?? true;
@@ -480,6 +502,9 @@
                         config.TagPrefix = document.querySelector('#TagPrefix').value;
                         config.SafeTagPrefix = document.querySelector('#SafeTagPrefix').value;
                         config.MinVotesThreshold = parseInt(document.querySelector('#MinVotesThreshold').value) || 3;
+                        config.UseConfidenceScoring = document.querySelector('#UseConfidenceScoring').checked;
+                        config.MinConfidenceThreshold = parseFloat(document.querySelector('#MinConfidenceThreshold').value) || 0.7;
+                        config.ShowConfidenceInTags = document.querySelector('#ShowConfidenceInTags').checked;
 
                         // Trigger filtering
                         config.ShowAllTriggers = document.querySelector('#ShowAllTriggers').checked;

--- a/Jellyfin.Plugin.DoesTheDogDie/Constants.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/Constants.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Jellyfin.Plugin.DoesTheDogDie;
 
 /// <summary>
@@ -11,9 +13,9 @@ public static class Constants
     public const string ApiKey = "37410a353ce46488ec077d0c73ef1c2e";
 
     /// <summary>
-    /// The DoesTheDogDie API base URL.
+    /// The default DoesTheDogDie API base URL.
     /// </summary>
-    public const string ApiBaseUrl = "https://www.doesthedogdie.com";
+    public const string DefaultApiBaseUrl = "https://www.doesthedogdie.com";
 
     /// <summary>
     /// The provider name displayed in Jellyfin UI.
@@ -39,4 +41,11 @@ public static class Constants
     /// DTDD item type ID for TV shows.
     /// </summary>
     public const int DtddItemTypeSeries = 16;
+
+    /// <summary>
+    /// Gets the DoesTheDogDie API base URL. Honors the DTDD_API_BASE_URL environment variable
+    /// for E2E test redirection; falls back to <see cref="DefaultApiBaseUrl"/>.
+    /// </summary>
+    public static string ApiBaseUrl =>
+        Environment.GetEnvironmentVariable("DTDD_API_BASE_URL") ?? DefaultApiBaseUrl;
 }

--- a/Jellyfin.Plugin.DoesTheDogDie/Providers/DtddEpisodeProvider.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/Providers/DtddEpisodeProvider.cs
@@ -117,7 +117,7 @@ public class DtddEpisodeProvider : ICustomMetadataProvider<Episode>, IHasOrder
                 continue;
             }
 
-            var tagName = $"{config.TagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.TagPrefix, trigger, config)!;
 
             if (!item.Tags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {

--- a/Jellyfin.Plugin.DoesTheDogDie/Providers/DtddMovieProvider.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/Providers/DtddMovieProvider.cs
@@ -135,7 +135,7 @@ public class DtddMovieProvider : ICustomMetadataProvider<Movie>, IHasOrder
                 continue;
             }
 
-            var tagName = $"{config.TagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.TagPrefix, trigger, config)!;
             if (!existingTags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {
                 existingTags.Add(tagName);
@@ -154,7 +154,7 @@ public class DtddMovieProvider : ICustomMetadataProvider<Movie>, IHasOrder
                 continue;
             }
 
-            var tagName = $"{config.SafeTagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.SafeTagPrefix, trigger, config)!;
             if (!existingTags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {
                 existingTags.Add(tagName);

--- a/Jellyfin.Plugin.DoesTheDogDie/Providers/DtddSeasonProvider.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/Providers/DtddSeasonProvider.cs
@@ -117,7 +117,7 @@ public class DtddSeasonProvider : ICustomMetadataProvider<Season>, IHasOrder
                 continue;
             }
 
-            var tagName = $"{config.TagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.TagPrefix, trigger, config)!;
 
             if (!item.Tags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {

--- a/Jellyfin.Plugin.DoesTheDogDie/Providers/DtddSeriesProvider.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/Providers/DtddSeriesProvider.cs
@@ -131,7 +131,7 @@ public class DtddSeriesProvider : ICustomMetadataProvider<Series>, IHasOrder
                 continue;
             }
 
-            var tagName = $"{config.TagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.TagPrefix, trigger, config)!;
             if (!existingTags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {
                 existingTags.Add(tagName);
@@ -150,7 +150,7 @@ public class DtddSeriesProvider : ICustomMetadataProvider<Series>, IHasOrder
                 continue;
             }
 
-            var tagName = $"{config.SafeTagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.SafeTagPrefix, trigger, config)!;
             if (!existingTags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {
                 existingTags.Add(tagName);

--- a/Jellyfin.Plugin.DoesTheDogDie/ScheduledTasks/DtddRefreshTask.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/ScheduledTasks/DtddRefreshTask.cs
@@ -242,7 +242,7 @@ public class DtddRefreshTask : IScheduledTask
                 continue;
             }
 
-            var tagName = $"{config.TagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.TagPrefix, trigger, config)!;
             if (!existingTags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {
                 existingTags.Add(tagName);
@@ -261,7 +261,7 @@ public class DtddRefreshTask : IScheduledTask
                 continue;
             }
 
-            var tagName = $"{config.SafeTagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.SafeTagPrefix, trigger, config)!;
             if (!existingTags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {
                 existingTags.Add(tagName);

--- a/Jellyfin.Plugin.DoesTheDogDie/ScheduledTasks/DtddRefreshTask.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/ScheduledTasks/DtddRefreshTask.cs
@@ -144,6 +144,9 @@ public class DtddRefreshTask : IScheduledTask
     {
         var items = new List<BaseItem>();
 
+        // Select all movies/series that have an IMDB ID. This lets the task do the
+        // initial population on existing libraries (which have no DTDD ID yet) as well
+        // as refresh items already tagged. Items without an IMDB ID are skipped later.
         if (config.EnableMovies)
         {
             var movies = _libraryManager.GetItemList(new InternalItemsQuery
@@ -152,7 +155,7 @@ public class DtddRefreshTask : IScheduledTask
                 IncludeItemTypes = new[] { BaseItemKind.Movie },
                 HasAnyProviderId = new Dictionary<string, string>
                 {
-                    { Constants.ProviderId, string.Empty }
+                    { MetadataProvider.Imdb.ToString(), string.Empty }
                 }
             });
             items.AddRange(movies);
@@ -166,7 +169,7 @@ public class DtddRefreshTask : IScheduledTask
                 IncludeItemTypes = new[] { BaseItemKind.Series },
                 HasAnyProviderId = new Dictionary<string, string>
                 {
-                    { Constants.ProviderId, string.Empty }
+                    { MetadataProvider.Imdb.ToString(), string.Empty }
                 }
             });
             items.AddRange(series);
@@ -205,9 +208,14 @@ public class DtddRefreshTask : IScheduledTask
         if (config.AddWarningTags)
         {
             var tagsChanged = UpdateWarningTags(item, details, config);
+            await item.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken)
+                .ConfigureAwait(false);
             return tagsChanged;
         }
 
+        // Even if tags are disabled, persist the (possibly updated) DTDD provider ID.
+        await item.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken)
+            .ConfigureAwait(false);
         return false;
     }
 

--- a/Jellyfin.Plugin.DoesTheDogDie/Scoring/BetaConfidenceCalculator.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/Scoring/BetaConfidenceCalculator.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Jellyfin.Plugin.DoesTheDogDie.Scoring;
+
+/// <summary>
+/// Calculates statistical confidence that a trigger applies using the
+/// Wilson score interval lower bound.
+/// </summary>
+public static class BetaConfidenceCalculator
+{
+    /// <summary>
+    /// Z-score for a 95% confidence interval.
+    /// </summary>
+    private const double Z = 1.96;
+
+    /// <summary>
+    /// Calculates the lower bound of the 95% Wilson score confidence interval
+    /// for the proportion of positive votes.
+    /// </summary>
+    /// <param name="positiveVotes">Number of votes agreeing the trigger applies.</param>
+    /// <param name="totalVotes">Total number of votes cast.</param>
+    /// <returns>Confidence score between 0.0 and 1.0.</returns>
+    public static double CalculateConfidence(int positiveVotes, int totalVotes)
+    {
+        if (totalVotes <= 0 || positiveVotes <= 0)
+        {
+            return 0.0;
+        }
+
+        var n = (double)totalVotes;
+        var p = Math.Min(positiveVotes, totalVotes) / n;
+        var zSquared = Z * Z;
+
+        var numerator = p + (zSquared / (2 * n))
+            - (Z * Math.Sqrt(((p * (1 - p)) + (zSquared / (4 * n))) / n));
+        var lowerBound = numerator / (1 + (zSquared / n));
+
+        return Math.Clamp(lowerBound, 0.0, 1.0);
+    }
+}

--- a/Jellyfin.Plugin.DoesTheDogDie/Services/DtddLibraryScanService.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/Services/DtddLibraryScanService.cs
@@ -170,7 +170,7 @@ public class DtddLibraryScanService : IHostedService
                 continue;
             }
 
-            var tagName = $"{config.TagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.TagPrefix, trigger, config)!;
             if (!existingTags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {
                 existingTags.Add(tagName);
@@ -189,7 +189,7 @@ public class DtddLibraryScanService : IHostedService
                 continue;
             }
 
-            var tagName = $"{config.SafeTagPrefix} {trigger.Topic.Name}";
+            var tagName = TriggerTagFormatter.FormatTagName(config.SafeTagPrefix, trigger, config)!;
             if (!existingTags.Contains(tagName, StringComparer.OrdinalIgnoreCase))
             {
                 existingTags.Add(tagName);

--- a/Jellyfin.Plugin.DoesTheDogDie/Services/DtddLibraryScanService.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/Services/DtddLibraryScanService.cs
@@ -134,6 +134,11 @@ public class DtddLibraryScanService : IHostedService
                 AddWarningTags(item, details, config);
             }
 
+            // Persist the provider ID and tags back to the library database.
+            // Without this, the in-memory changes are discarded when the method returns.
+            await item.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, CancellationToken.None)
+                .ConfigureAwait(false);
+
             _logger.LogInformation(
                 "Added DTDD data for {ItemName} (DTDD ID: {DtddId})",
                 item.Name,

--- a/Jellyfin.Plugin.DoesTheDogDie/TriggerFilter.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/TriggerFilter.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.DoesTheDogDie.Api.Models;
 using Jellyfin.Plugin.DoesTheDogDie.Configuration;
+using Jellyfin.Plugin.DoesTheDogDie.Scoring;
 
 namespace Jellyfin.Plugin.DoesTheDogDie;
 
@@ -17,6 +19,12 @@ public static class TriggerFilter
     /// <returns>True if the trigger should be included, false otherwise.</returns>
     public static bool ShouldIncludeTrigger(DtddTopicItemStat trigger, PluginConfiguration config)
     {
+        // Statistical confidence filter applies regardless of category selection
+        if (config.UseConfidenceScoring && GetConfidence(trigger) < config.MinConfidenceThreshold)
+        {
+            return false;
+        }
+
         // Master switch - include everything
         if (config.ShowAllTriggers)
         {
@@ -56,6 +64,18 @@ public static class TriggerFilter
 
         // Otherwise, topic must be explicitly enabled
         return config.EnabledTopicIds.Contains(topic.Id);
+    }
+
+    /// <summary>
+    /// Calculates the statistical confidence that a trigger's majority vote
+    /// direction is correct, using the Wilson score interval lower bound.
+    /// </summary>
+    /// <param name="trigger">The trigger to evaluate.</param>
+    /// <returns>Confidence score between 0.0 and 1.0.</returns>
+    public static double GetConfidence(DtddTopicItemStat trigger)
+    {
+        var majorityVotes = Math.Max(trigger.YesSum, trigger.NoSum);
+        return BetaConfidenceCalculator.CalculateConfidence(majorityVotes, trigger.TotalVotes);
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.DoesTheDogDie/TriggerTagFormatter.cs
+++ b/Jellyfin.Plugin.DoesTheDogDie/TriggerTagFormatter.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Globalization;
+using Jellyfin.Plugin.DoesTheDogDie.Api.Models;
+using Jellyfin.Plugin.DoesTheDogDie.Configuration;
+
+namespace Jellyfin.Plugin.DoesTheDogDie;
+
+/// <summary>
+/// Helper class for building tag names from triggers.
+/// </summary>
+public static class TriggerTagFormatter
+{
+    /// <summary>
+    /// Builds the tag name for a trigger, optionally appending the confidence
+    /// percentage (rounded to the nearest 5%) when enabled in configuration.
+    /// </summary>
+    /// <param name="prefix">The tag prefix (e.g. "CW:" or "Safe:").</param>
+    /// <param name="trigger">The trigger to format.</param>
+    /// <param name="config">The plugin configuration.</param>
+    /// <returns>The formatted tag name, or null if the trigger has no topic.</returns>
+    public static string? FormatTagName(string prefix, DtddTopicItemStat trigger, PluginConfiguration config)
+    {
+        if (trigger.Topic == null)
+        {
+            return null;
+        }
+
+        var tagName = $"{prefix} {trigger.Topic.Name}";
+
+        if (config.ShowConfidenceInTags)
+        {
+            var confidence = TriggerFilter.GetConfidence(trigger);
+            var percent = (int)(Math.Round(confidence * 100 / 5.0) * 5);
+            tagName += string.Create(CultureInfo.InvariantCulture, $" ({percent}%)");
+        }
+
+        return tagName;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Copy the contents of `Jellyfin.Plugin.DoesTheDogDie/bin/Release/net9.0/publish/`
 | Tag Prefix | Customize warning tag prefix | `CW:` |
 | Safe Tag Prefix | Customize safe tag prefix | `Safe:` |
 | Min Votes Threshold | Minimum votes required to show a trigger | `3` |
+| Use Confidence Scoring | Filter triggers by Wilson score confidence instead of raw vote counts alone | `false` |
+| Min Confidence Threshold | Confidence (0.0–1.0) required to show a trigger when confidence scoring is enabled | `0.7` |
+| Show Confidence In Tags | Append confidence to tag names, e.g. `CW: a dog dies (95%)` | `false` |
 | Trigger Categories | Select which categories to track (Animal, Violence, etc.) | All |
 
 ## Requirements

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Does The Dog Die"
 guid: "eb5d7894-8eef-4b36-aa6f-5d124e828ce1"
-version: "0.1.0.0"
+version: "0.1.1.0"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Display content warnings from DoesTheDogDie.com"
@@ -15,9 +15,8 @@ owner: "theflanman"
 artifacts:
 - "Jellyfin.Plugin.DoesTheDogDie.dll"
 changelog: |
-  - Initial release with DoesTheDogDie.com integration
-  - Hierarchical trigger filtering (categories and topics)
-  - Content warning tags (CW:) and safe tags (Safe:)
-  - Background service for automatic lookups
-  - Scheduled task for periodic refresh
-  - External ID and URL providers
+  - Statistical confidence scoring (Wilson score interval) for trigger filtering
+  - Optional confidence percentage in tag names, e.g. "CW: a dog dies (95%)"
+  - New settings: UseConfidenceScoring, MinConfidenceThreshold, ShowConfidenceInTags
+  - Fix: tags now persist to the library from scan service and refresh task
+  - Fix: refresh task seeds items without a DTDD id on fresh installs

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Fixtures/JellyfinFixture.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Fixtures/JellyfinFixture.cs
@@ -1,0 +1,188 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
+using Xunit;
+
+namespace Jellyfin.Plugin.DoesTheDogDie.E2ETests.Fixtures;
+
+/// <summary>
+/// Spins up WireMock + Jellyfin LSIO containers on a shared Docker network,
+/// drives the startup wizard, authenticates, and adds two libraries pointing
+/// at the synthetic NFO fixtures.
+/// </summary>
+public sealed class JellyfinFixture : IAsyncLifetime
+{
+    public static readonly Guid PluginId = Guid.Parse("eb5d7894-8eef-4b36-aa6f-5d124e828ce1");
+
+    private const string WireMockImage = "wiremock/wiremock:3.10.0";
+    private const string JellyfinImage = "lscr.io/linuxserver/jellyfin:10.11.8";
+
+    private INetwork? _network;
+    private IContainer? _wiremock;
+    private IContainer? _jellyfin;
+
+    internal JellyfinClient Client { get; private set; } = null!;
+
+    internal Uri JellyfinBaseAddress { get; private set; } = null!;
+
+    internal string? JellyfinLogFile { get; private set; }
+
+    public async Task InitializeAsync()
+    {
+        var paths = ResolvePaths();
+        EnsurePluginPublished(paths.PluginPublishDir);
+        WriteMetaJson(paths.PluginPublishDir);
+
+        _network = new NetworkBuilder()
+            .WithName($"dtdd-e2e-{Guid.NewGuid():N}")
+            .Build();
+        await _network.CreateAsync();
+
+        _wiremock = new ContainerBuilder()
+            .WithImage(WireMockImage)
+            .WithNetwork(_network)
+            .WithNetworkAliases("wiremock")
+            .WithBindMount(paths.StubsDir, "/home/wiremock/mappings", AccessMode.ReadOnly)
+            .WithCommand("--global-response-templating", "--verbose")
+            .WithPortBinding(8080, true)
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilHttpRequestIsSucceeded(r => r.ForPort(8080).ForPath("/__admin/health")))
+            .Build();
+        await _wiremock.StartAsync();
+
+        var logFile = Path.Combine(Path.GetTempPath(), $"jellyfin-dtdd-e2e-{Guid.NewGuid():N}.log");
+        var consumer = new FileLogConsumer(logFile);
+
+        _jellyfin = new ContainerBuilder()
+            .WithImage(JellyfinImage)
+            .WithNetwork(_network)
+            .WithNetworkAliases("jellyfin")
+            .WithEnvironment("PUID", "1000")
+            .WithEnvironment("PGID", "1000")
+            .WithEnvironment("TZ", "Etc/UTC")
+            .WithEnvironment("JELLYFIN_PublishedServerUrl", "http://localhost")
+            .WithEnvironment("DTDD_API_BASE_URL", "http://wiremock:8080")
+            .WithBindMount(paths.PluginPublishDir, "/config/data/plugins/DoesTheDogDie_0.1.0.0", AccessMode.ReadOnly)
+            .WithBindMount(paths.MoviesDir, "/data/movies", AccessMode.ReadOnly)
+            .WithBindMount(paths.TvDir, "/data/tvshows", AccessMode.ReadOnly)
+            .WithPortBinding(8096, true)
+            .WithOutputConsumer(consumer)
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilHttpRequestIsSucceeded(r => r.ForPort(8096).ForPath("/System/Info/Public").WithMethod(System.Net.Http.HttpMethod.Get)))
+            .Build();
+        JellyfinLogFile = logFile;
+        await _jellyfin.StartAsync();
+
+        var mappedPort = _jellyfin.GetMappedPublicPort(8096);
+        JellyfinBaseAddress = new Uri($"http://localhost:{mappedPort}");
+
+        Client = new JellyfinClient(JellyfinBaseAddress);
+        await Client.WaitForServerReadyAsync(TimeSpan.FromSeconds(180));
+        await Client.CompleteStartupWizardAsync(adminUser: "test", password: "test");
+        await Client.LoginAsync("test", "test");
+        await Client.AddLibraryAsync("Movies", "movies", "/data/movies");
+        await Client.AddLibraryAsync("Shows", "tvshows", "/data/tvshows");
+
+        // Initial scan so subsequent tests see items present.
+        await Client.TriggerAndWaitScanAsync(TimeSpan.FromSeconds(120));
+    }
+
+    public async Task DisposeAsync()
+    {
+        Client?.Dispose();
+        if (_jellyfin is not null)
+        {
+            await _jellyfin.DisposeAsync();
+        }
+
+        if (_wiremock is not null)
+        {
+            await _wiremock.DisposeAsync();
+        }
+
+        if (_network is not null)
+        {
+            await _network.DeleteAsync();
+        }
+    }
+
+    private static FixturePaths ResolvePaths()
+    {
+        var baseDir = AppContext.BaseDirectory;
+        // bin/Debug/net9.0 → up 5 to repo root
+        var repoRoot = Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "..", ".."));
+        return new FixturePaths(
+            StubsDir: Path.Combine(baseDir, "Stubs", "wiremock-mappings"),
+            MoviesDir: Path.Combine(baseDir, "Fixtures", "media", "movies"),
+            TvDir: Path.Combine(baseDir, "Fixtures", "media", "tv"),
+            PluginPublishDir: Path.Combine(repoRoot, "Jellyfin.Plugin.DoesTheDogDie", "bin", "Debug", "net9.0", "publish"));
+    }
+
+    private static void EnsurePluginPublished(string publishDir)
+    {
+        if (!Directory.Exists(publishDir) || Directory.GetFiles(publishDir, "Jellyfin.Plugin.DoesTheDogDie.dll").Length == 0)
+        {
+            throw new InvalidOperationException(
+                $"Plugin publish output not found at {publishDir}. " +
+                "The E2E csproj should run `dotnet publish` BeforeTargets=Build; check the build log.");
+        }
+    }
+
+    private static void WriteMetaJson(string publishDir)
+    {
+        // Jellyfin's plugin loader needs meta.json to register a plugin. Defaults observed in
+        // installed plugins on a real server: status="Active" (otherwise PluginManager treats
+        // the plugin as Disabled), autoUpdate=true, assemblies=[]. Without "Active" the plugin
+        // never reaches the IsEnabledAndSupported gate and never loads.
+        var meta = """
+        {
+          "guid": "eb5d7894-8eef-4b36-aa6f-5d124e828ce1",
+          "name": "Does The Dog Die",
+          "overview": "Display content warnings from DoesTheDogDie.com",
+          "description": "Integrates with DoesTheDogDie.com to display content warnings and trigger information.",
+          "category": "General",
+          "owner": "theflanman",
+          "targetAbi": "10.11.0.0",
+          "version": "0.1.0.0",
+          "status": "Active",
+          "autoUpdate": false,
+          "imagePath": "",
+          "assemblies": [],
+          "changelog": ""
+        }
+        """;
+        File.WriteAllText(Path.Combine(publishDir, "meta.json"), meta);
+    }
+
+    private sealed record FixturePaths(string StubsDir, string MoviesDir, string TvDir, string PluginPublishDir);
+
+    private sealed class FileLogConsumer : DotNet.Testcontainers.Configurations.IOutputConsumer
+    {
+        private readonly System.IO.FileStream _stdout;
+        private readonly System.IO.FileStream _stderr;
+
+        public FileLogConsumer(string path)
+        {
+            _stdout = System.IO.File.Open(path, System.IO.FileMode.Create, System.IO.FileAccess.Write, System.IO.FileShare.Read);
+            _stderr = _stdout;
+        }
+
+        public bool Enabled => true;
+
+        public System.IO.Stream Stdout => _stdout;
+
+        public System.IO.Stream Stderr => _stderr;
+
+        public void Dispose() => _stdout.Dispose();
+    }
+}
+
+[CollectionDefinition("Jellyfin", DisableParallelization = true)]
+public sealed class JellyfinCollection : ICollectionFixture<JellyfinFixture>
+{
+}

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Fixtures/media/movies/John Wick (2014)/John Wick (2014).nfo
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Fixtures/media/movies/John Wick (2014)/John Wick (2014).nfo
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<movie>
+  <title>John Wick</title>
+  <originaltitle>John Wick</originaltitle>
+  <sorttitle>John Wick</sorttitle>
+  <year>2014</year>
+  <plot>An ex-hitman comes out of retirement to track down the gangsters that killed his dog and took everything from him.</plot>
+  <runtime>101</runtime>
+  <imdbid>tt2911666</imdbid>
+  <tmdbid>245891</tmdbid>
+  <uniqueid type="imdb" default="true">tt2911666</uniqueid>
+  <uniqueid type="tmdb">245891</uniqueid>
+</movie>

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Fixtures/media/tv/Breaking Bad/Season 01/Breaking Bad S01E01 - Pilot.nfo
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Fixtures/media/tv/Breaking Bad/Season 01/Breaking Bad S01E01 - Pilot.nfo
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<episodedetails>
+  <title>Pilot</title>
+  <season>1</season>
+  <episode>1</episode>
+  <plot>Walter White, a chemistry teacher, discovers he has cancer and decides to start producing meth.</plot>
+</episodedetails>

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Fixtures/media/tv/Breaking Bad/tvshow.nfo
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Fixtures/media/tv/Breaking Bad/tvshow.nfo
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<tvshow>
+  <title>Breaking Bad</title>
+  <originaltitle>Breaking Bad</originaltitle>
+  <sorttitle>Breaking Bad</sorttitle>
+  <year>2008</year>
+  <plot>A high school chemistry teacher diagnosed with inoperable lung cancer turns to manufacturing and selling methamphetamine in order to secure his family's financial future.</plot>
+  <imdbid>tt0903747</imdbid>
+  <tmdbid>1396</tmdbid>
+  <uniqueid type="imdb" default="true">tt0903747</uniqueid>
+  <uniqueid type="tmdb">1396</uniqueid>
+</tvshow>

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Jellyfin.Plugin.DoesTheDogDie.E2ETests.csproj
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Jellyfin.Plugin.DoesTheDogDie.E2ETests.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CA1707;CA2007;CS1591;SA1600;SA1633;SA0001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Testcontainers" Version="4.0.0" />
+    <PackageReference Include="WireMock.Net" Version="1.6.7" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Jellyfin.Plugin.DoesTheDogDie\Jellyfin.Plugin.DoesTheDogDie.csproj" />
+  </ItemGroup>
+
+  <Target Name="PublishPluginForE2E" BeforeTargets="Build">
+    <Exec Command="dotnet publish &quot;$(MSBuildThisFileDirectory)../../Jellyfin.Plugin.DoesTheDogDie/Jellyfin.Plugin.DoesTheDogDie.csproj&quot; -c Debug --nologo -v quiet" />
+  </Target>
+
+  <ItemGroup>
+    <None Update="Stubs\**\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Fixtures\media\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/JellyfinClient.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/JellyfinClient.cs
@@ -1,0 +1,366 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.DoesTheDogDie.E2ETests;
+
+/// <summary>
+/// Thin REST wrapper around a running Jellyfin instance. Drives the startup wizard,
+/// authenticates, manages libraries/plugin config, and triggers + waits for scans.
+/// </summary>
+internal sealed class JellyfinClient : IDisposable
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly HttpClient _http;
+    private readonly string _deviceId;
+    private string? _accessToken;
+
+    public JellyfinClient(Uri baseAddress)
+    {
+        _http = new HttpClient { BaseAddress = baseAddress, Timeout = TimeSpan.FromSeconds(60) };
+        _deviceId = Guid.NewGuid().ToString("N");
+        SetAuthorizationHeader();
+    }
+
+    public string? AccessToken => _accessToken;
+
+    public async Task WaitForServerReadyAsync(TimeSpan timeout, CancellationToken ct = default)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        Exception? last = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                // /Startup/Configuration returns 200 only after the server has finished booting
+                // and the startup wizard endpoints are wired up. /System/Info/Public flips to 200
+                // much earlier (while the app is still initializing) and produces 503s downstream.
+                using var resp = await _http.GetAsync("/Startup/Configuration", ct);
+                if (resp.IsSuccessStatusCode)
+                {
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                last = ex;
+            }
+
+            await Task.Delay(1000, ct);
+        }
+
+        throw new TimeoutException($"Jellyfin wizard endpoint not ready within {timeout}", last);
+    }
+
+    public async Task CompleteStartupWizardAsync(string adminUser, string password, string uiCulture = "en-US", CancellationToken ct = default)
+    {
+        // The wizard endpoints occasionally return 500/503 in the first second or two after
+        // Jellyfin's web pipeline comes up — plugins are still being registered. Retry briefly.
+        await SendWithRetryAsync(
+            () => _http.PostAsJsonAsync("/Startup/Configuration", new StartupConfigurationDto
+            {
+                UICulture = uiCulture,
+                MetadataCountryCode = "US",
+                PreferredMetadataLanguage = "en",
+            }, JsonOptions, ct),
+            ct: ct);
+
+        // GET /Startup/User triggers _userManager.InitializeAsync which seeds the default user
+        // record. POST then mutates that record. Without the GET first, POST throws
+        // "Sequence contains no elements" on _userManager.Users.First().
+        await SendWithRetryAsync(() => _http.GetAsync("/Startup/User", ct), ct: ct);
+        await SendWithRetryAsync(
+            () => _http.PostAsJsonAsync("/Startup/User", new StartupUserDto
+            {
+                Name = adminUser,
+                Password = password,
+            }, JsonOptions, ct),
+            ct: ct);
+
+        await SendWithRetryAsync(
+            () => _http.PostAsJsonAsync("/Startup/RemoteAccess", new StartupRemoteAccessDto
+            {
+                EnableRemoteAccess = false,
+                EnableAutomaticPortMapping = false,
+            }, JsonOptions, ct),
+            ct: ct);
+
+        await SendWithRetryAsync(() => _http.PostAsync("/Startup/Complete", content: null, ct), ct: ct);
+    }
+
+    private static async Task SendWithRetryAsync(
+        Func<Task<HttpResponseMessage>> send,
+        int maxAttempts = 12,
+        CancellationToken ct = default)
+    {
+        HttpResponseMessage? last = null;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            last?.Dispose();
+            try
+            {
+                last = await send();
+                if (last.IsSuccessStatusCode)
+                {
+                    last.Dispose();
+                    return;
+                }
+
+                if ((int)last.StatusCode < 500)
+                {
+                    last.EnsureSuccessStatusCode();
+                }
+            }
+            catch (HttpRequestException) when (attempt < maxAttempts)
+            {
+                // transient — retry
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(2), ct);
+        }
+
+        last?.EnsureSuccessStatusCode();
+    }
+
+    public async Task LoginAsync(string username, string password, CancellationToken ct = default)
+    {
+        var resp = await _http.PostAsJsonAsync("/Users/AuthenticateByName", new
+        {
+            Username = username,
+            Pw = password,
+        }, JsonOptions, ct);
+        resp.EnsureSuccessStatusCode();
+
+        var auth = await resp.Content.ReadFromJsonAsync<AuthenticationResultDto>(JsonOptions, ct);
+        _accessToken = auth?.AccessToken ?? throw new InvalidOperationException("AuthenticateByName returned no AccessToken");
+        SetAuthorizationHeader();
+    }
+
+    public async Task AddLibraryAsync(string name, string collectionType, string path, CancellationToken ct = default)
+    {
+        var url = $"/Library/VirtualFolders?name={Uri.EscapeDataString(name)}&collectionType={collectionType}&paths={Uri.EscapeDataString(path)}&refreshLibrary=false";
+        var resp = await _http.PostAsync(url, content: null, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task SetPluginConfigurationAsync(Guid pluginId, object configuration, CancellationToken ct = default)
+    {
+        var resp = await _http.PostAsJsonAsync($"/Plugins/{pluginId:D}/Configuration", configuration, JsonOptions, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task<JsonDocument> GetPluginConfigurationAsync(Guid pluginId, CancellationToken ct = default)
+    {
+        var resp = await _http.GetAsync($"/Plugins/{pluginId:D}/Configuration", ct);
+        resp.EnsureSuccessStatusCode();
+        var stream = await resp.Content.ReadAsStreamAsync(ct);
+        return await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+    }
+
+    public async Task TriggerLibraryScanAsync(CancellationToken ct = default)
+    {
+        var resp = await _http.PostAsync("/Library/Refresh", content: null, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task WaitForScanIdleAsync(TimeSpan timeout, CancellationToken ct = default)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        // First wait for the scan to start (status leaves Idle), then wait for it to return to Idle.
+        var observedRunning = false;
+        while (DateTime.UtcNow < deadline)
+        {
+            var task = await GetScanLibraryTaskAsync(ct);
+            var state = task?.State ?? "Idle";
+            if (!observedRunning && state != "Idle")
+            {
+                observedRunning = true;
+            }
+            else if (observedRunning && state == "Idle")
+            {
+                return;
+            }
+            else if (observedRunning)
+            {
+                // still running
+            }
+
+            await Task.Delay(500, ct);
+        }
+
+        // If we never saw it running, it may have completed instantly — accept Idle as success.
+        var final = await GetScanLibraryTaskAsync(ct);
+        if (final?.State == "Idle")
+        {
+            return;
+        }
+
+        throw new TimeoutException($"Library scan did not return to Idle within {timeout}");
+    }
+
+    public async Task TriggerAndWaitScanAsync(TimeSpan? timeout = null, CancellationToken ct = default)
+    {
+        await TriggerLibraryScanAsync(ct);
+        await WaitForScanIdleAsync(timeout ?? TimeSpan.FromSeconds(120), ct);
+    }
+
+    public async Task RefreshItemMetadataAsync(string itemId, bool replaceAllMetadata = false, CancellationToken ct = default)
+    {
+        var url = $"/Items/{itemId}/Refresh?metadataRefreshMode=FullRefresh&imageRefreshMode=Default&replaceAllMetadata={(replaceAllMetadata ? "true" : "false")}&replaceAllImages=false";
+        var resp = await _http.PostAsync(url, content: null, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task<HttpResponseMessage> GetConfigurationPageAsync(string pluginDisplayName, CancellationToken ct = default)
+    {
+        var url = $"/web/ConfigurationPage?name={Uri.EscapeDataString(pluginDisplayName)}";
+        return await _http.GetAsync(url, ct);
+    }
+
+    public async Task<List<JellyfinItemDto>> GetItemsAsync(string includeItemTypes, CancellationToken ct = default)
+    {
+        var url = $"/Items?Recursive=true&Fields=Tags,ProviderIds,Overview&IncludeItemTypes={includeItemTypes}";
+        var resp = await _http.GetAsync(url, ct);
+        resp.EnsureSuccessStatusCode();
+        var page = await resp.Content.ReadFromJsonAsync<ItemsResultDto>(JsonOptions, ct);
+        return page?.Items ?? new List<JellyfinItemDto>();
+    }
+
+    public Task LockOverviewAsync(string itemId, CancellationToken ct = default)
+        => SetLockedFieldsAsync(itemId, new[] { "Overview" }, ct);
+
+    public Task UnlockAllFieldsAsync(string itemId, CancellationToken ct = default)
+        => SetLockedFieldsAsync(itemId, Array.Empty<string>(), ct);
+
+    private async Task SetLockedFieldsAsync(string itemId, string[] lockedFields, CancellationToken ct)
+    {
+        var itemResp = await _http.GetAsync($"/Items/{itemId}", ct);
+        itemResp.EnsureSuccessStatusCode();
+        var stream = await itemResp.Content.ReadAsStreamAsync(ct);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+
+        var node = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(doc.RootElement.GetRawText(), JsonOptions)!;
+        node["LockedFields"] = JsonSerializer.SerializeToElement(lockedFields, JsonOptions);
+
+        var update = await _http.PostAsJsonAsync($"/Items/{itemId}", node, JsonOptions, ct);
+        update.EnsureSuccessStatusCode();
+    }
+
+    public void Dispose() => _http.Dispose();
+
+    private async Task<ScheduledTaskDto?> GetScanLibraryTaskAsync(CancellationToken ct)
+    {
+        var resp = await _http.GetAsync("/ScheduledTasks", ct);
+        resp.EnsureSuccessStatusCode();
+        var tasks = await resp.Content.ReadFromJsonAsync<List<ScheduledTaskDto>>(JsonOptions, ct);
+        if (tasks is null)
+        {
+            return null;
+        }
+
+        foreach (var t in tasks)
+        {
+            if (string.Equals(t.Key, "RefreshLibrary", StringComparison.OrdinalIgnoreCase) ||
+                (t.Name?.Contains("Scan", StringComparison.OrdinalIgnoreCase) == true && t.Name?.Contains("Library", StringComparison.OrdinalIgnoreCase) == true))
+            {
+                return t;
+            }
+        }
+
+        return null;
+    }
+
+    private void SetAuthorizationHeader()
+    {
+        _http.DefaultRequestHeaders.Remove("Authorization");
+        var parts = new List<string>
+        {
+            "Client=\"E2E\"",
+            "Device=\"xunit\"",
+            $"DeviceId=\"{_deviceId}\"",
+            "Version=\"1.0.0\"",
+        };
+        if (!string.IsNullOrEmpty(_accessToken))
+        {
+            parts.Insert(0, $"Token=\"{_accessToken}\"");
+        }
+
+        _http.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", "MediaBrowser " + string.Join(", ", parts));
+    }
+
+    private sealed class StartupConfigurationDto
+    {
+        public string? UICulture { get; set; }
+
+        public string? MetadataCountryCode { get; set; }
+
+        public string? PreferredMetadataLanguage { get; set; }
+    }
+
+    private sealed class StartupUserDto
+    {
+        public string? Name { get; set; }
+
+        public string? Password { get; set; }
+    }
+
+    private sealed class StartupRemoteAccessDto
+    {
+        public bool EnableRemoteAccess { get; set; }
+
+        public bool EnableAutomaticPortMapping { get; set; }
+    }
+
+    private sealed class AuthenticationResultDto
+    {
+        public string? AccessToken { get; set; }
+
+        public string? ServerId { get; set; }
+    }
+
+    internal sealed class ScheduledTaskDto
+    {
+        public string? Name { get; set; }
+
+        public string? Key { get; set; }
+
+        public string? State { get; set; }
+
+        public double? CurrentProgressPercentage { get; set; }
+    }
+
+    internal sealed class ItemsResultDto
+    {
+        public List<JellyfinItemDto> Items { get; set; } = new();
+
+        public int TotalRecordCount { get; set; }
+    }
+
+    internal sealed class JellyfinItemDto
+    {
+        public string Id { get; set; } = string.Empty;
+
+        public string? Name { get; set; }
+
+        public string? Type { get; set; }
+
+        public string? Overview { get; set; }
+
+        public string? SeriesId { get; set; }
+
+        public List<string> Tags { get; set; } = new();
+
+        public Dictionary<string, string> ProviderIds { get; set; } = new();
+    }
+}

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Stubs/wiremock-mappings/media-breaking-bad.json
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Stubs/wiremock-mappings/media-breaking-bad.json
@@ -1,0 +1,41 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/media/5678"
+  },
+  "response": {
+    "status": 200,
+    "headers": { "Content-Type": "application/json" },
+    "jsonBody": {
+      "item": {
+        "id": 5678,
+        "name": "Breaking Bad",
+        "cleanName": "breaking bad",
+        "releaseYear": "2008",
+        "imdbId": "tt0903747",
+        "tmdbId": 1396,
+        "numRatings": 1200,
+        "verified": 1,
+        "staffVerified": 1,
+        "ItemTypeId": 16
+      },
+      "topicItemStats": [
+        {
+          "topicItemId": 2001,
+          "yesSum": 412,
+          "noSum": 6,
+          "numComments": 88,
+          "TopicId": 201,
+          "itemId": 5678,
+          "topic": {
+            "id": 201,
+            "name": "someone dies",
+            "notName": "no one dies",
+            "isSpoiler": false,
+            "isVisible": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Stubs/wiremock-mappings/media-john-wick.json
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Stubs/wiremock-mappings/media-john-wick.json
@@ -1,0 +1,56 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/media/1234"
+  },
+  "response": {
+    "status": 200,
+    "headers": { "Content-Type": "application/json" },
+    "jsonBody": {
+      "item": {
+        "id": 1234,
+        "name": "John Wick",
+        "cleanName": "john wick",
+        "releaseYear": "2014",
+        "imdbId": "tt2911666",
+        "tmdbId": 245891,
+        "numRatings": 500,
+        "verified": 1,
+        "staffVerified": 1,
+        "ItemTypeId": 15
+      },
+      "topicItemStats": [
+        {
+          "topicItemId": 1001,
+          "yesSum": 87,
+          "noSum": 4,
+          "numComments": 12,
+          "TopicId": 101,
+          "itemId": 1234,
+          "topic": {
+            "id": 101,
+            "name": "an animal dies",
+            "notName": "no animals die",
+            "isSpoiler": false,
+            "isVisible": true
+          }
+        },
+        {
+          "topicItemId": 1002,
+          "yesSum": 256,
+          "noSum": 8,
+          "numComments": 30,
+          "TopicId": 102,
+          "itemId": 1234,
+          "topic": {
+            "id": 102,
+            "name": "someone is shot",
+            "notName": "no one is shot",
+            "isSpoiler": false,
+            "isVisible": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Stubs/wiremock-mappings/search-breaking-bad.json
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Stubs/wiremock-mappings/search-breaking-bad.json
@@ -1,0 +1,30 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/dddsearch",
+    "queryParameters": {
+      "imdb": { "equalTo": "tt0903747" }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": { "Content-Type": "application/json" },
+    "jsonBody": {
+      "items": [
+        {
+          "id": 5678,
+          "name": "Breaking Bad",
+          "cleanName": "breaking bad",
+          "releaseYear": "2008",
+          "imdbId": "tt0903747",
+          "tmdbId": 1396,
+          "numRatings": 1200,
+          "verified": 1,
+          "staffVerified": 1,
+          "ItemTypeId": 16
+        }
+      ],
+      "topics": []
+    }
+  }
+}

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Stubs/wiremock-mappings/search-john-wick.json
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Stubs/wiremock-mappings/search-john-wick.json
@@ -1,0 +1,30 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/dddsearch",
+    "queryParameters": {
+      "imdb": { "equalTo": "tt2911666" }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": { "Content-Type": "application/json" },
+    "jsonBody": {
+      "items": [
+        {
+          "id": 1234,
+          "name": "John Wick",
+          "cleanName": "john wick",
+          "releaseYear": "2014",
+          "imdbId": "tt2911666",
+          "tmdbId": 245891,
+          "numRatings": 500,
+          "verified": 1,
+          "staffVerified": 1,
+          "ItemTypeId": 15
+        }
+      ],
+      "topics": []
+    }
+  }
+}

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/TestHelpers.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/TestHelpers.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.DoesTheDogDie.E2ETests;
+
+internal static class TestHelpers
+{
+    /// <summary>
+    /// Polls <paramref name="condition"/> until it returns true, or throws on timeout.
+    /// Used to wait for asynchronous Jellyfin metadata refreshes to land.
+    /// </summary>
+    public static async Task WaitForAsync(
+        Func<Task<bool>> condition,
+        TimeSpan timeout,
+        TimeSpan? pollInterval = null,
+        string? failureMessage = null,
+        CancellationToken ct = default)
+    {
+        var poll = pollInterval ?? TimeSpan.FromMilliseconds(500);
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await condition())
+            {
+                return;
+            }
+
+            await Task.Delay(poll, ct);
+        }
+
+        throw new TimeoutException(failureMessage ?? $"Condition not met within {timeout}");
+    }
+
+    /// <summary>
+    /// Default plugin configuration used to reset between mutation tests.
+    /// Mirrors PluginConfiguration's constructor defaults.
+    /// </summary>
+    public static IDictionary<string, object> DefaultPluginConfig() => new Dictionary<string, object>
+    {
+        ["EnableMovies"] = true,
+        ["EnableSeries"] = true,
+        ["EnableBooks"] = true,
+        ["CacheDurationHours"] = 168,
+        ["MinVotesThreshold"] = 3,
+        ["AddWarningTags"] = true,
+        ["TagPrefix"] = "CW:",
+        ["SafeTagPrefix"] = "Safe:",
+        ["RefreshIntervalHours"] = 24,
+        ["ShowAllTriggers"] = true,
+        ["EnabledCategoryIds"] = Array.Empty<int>(),
+        ["EnabledTopicIds"] = Array.Empty<int>(),
+        ["AddDescriptionWarnings"] = false,
+        ["IncludeTopComment"] = false,
+        ["MaxCommentLength"] = 200,
+        ["HideSpoilerComments"] = true,
+    };
+
+    public static IDictionary<string, object> ConfigWith(params (string Key, object Value)[] overrides)
+    {
+        var cfg = DefaultPluginConfig();
+        foreach (var (k, v) in overrides)
+        {
+            cfg[k] = v;
+        }
+
+        return cfg;
+    }
+}

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/ConfigPageTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/ConfigPageTests.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Jellyfin.Plugin.DoesTheDogDie.E2ETests.Fixtures;
+using Xunit;
+
+namespace Jellyfin.Plugin.DoesTheDogDie.E2ETests.Tests;
+
+[Trait("Category", "E2E")]
+[Collection("Jellyfin")]
+public sealed class ConfigPageTests
+{
+    private readonly JellyfinFixture _fixture;
+
+    public ConfigPageTests(JellyfinFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task ConfigurationPage_IsServedAsHtml()
+    {
+        using var resp = await _fixture.Client.GetConfigurationPageAsync("Does The Dog Die");
+        resp.StatusCode.Should().Be(HttpStatusCode.OK, "Jellyfin should locate the embedded configPage.html resource by plugin name");
+        resp.Content.Headers.ContentType?.MediaType.Should().Be("text/html");
+    }
+
+    [Theory]
+    [InlineData("DoesTheDogDieConfigForm")]
+    [InlineData("DoesTheDogDieConfigPage")]
+    [InlineData("EnableMovies")]
+    [InlineData("EnableSeries")]
+    [InlineData("EnableBooks")]
+    [InlineData("MinVotesThreshold")]
+    [InlineData("TagPrefix")]
+    [InlineData("SafeTagPrefix")]
+    [InlineData("ShowAllTriggers")]
+    [InlineData("CategoriesContainer")]
+    public async Task ConfigurationPage_ContainsExpectedFormElement(string elementId)
+    {
+        using var resp = await _fixture.Client.GetConfigurationPageAsync("Does The Dog Die");
+        var html = await resp.Content.ReadAsStringAsync();
+        html.Should().Contain($"id=\"{elementId}\"", $"the config page must wire up the {elementId} control");
+    }
+
+    [Fact]
+    public async Task ConfigurationPage_HasTitleAndConfigJsHook()
+    {
+        using var resp = await _fixture.Client.GetConfigurationPageAsync("Does The Dog Die");
+        var html = await resp.Content.ReadAsStringAsync();
+
+        html.Should().Contain("<title>Does The Dog Die</title>");
+        html.Should().Contain("ApiClient.getPluginConfiguration", "save/load JS must hit the plugin configuration endpoint via the Jellyfin web ApiClient");
+        html.Should().Contain("ApiClient.updatePluginConfiguration");
+    }
+}

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/ConfigPersistenceTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/ConfigPersistenceTests.cs
@@ -148,6 +148,14 @@ public sealed class ConfigPersistenceTests
         {
             await ResetConfigAsync();
             await _fixture.Client.RefreshItemMetadataAsync(johnWick.Id, replaceAllMetadata: true);
+            await TestHelpers.WaitForAsync(
+                async () =>
+                {
+                    var refreshed = (await _fixture.Client.GetItemsAsync("Movie")).Single(m => m.Name == "John Wick");
+                    return refreshed.Tags.Contains("CW: an animal dies");
+                },
+                System.TimeSpan.FromSeconds(30),
+                failureMessage: "Cleanup: tags did not return after restoring default config");
         }
     }
 

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/ConfigPersistenceTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/ConfigPersistenceTests.cs
@@ -1,0 +1,197 @@
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Jellyfin.Plugin.DoesTheDogDie.E2ETests.Fixtures;
+using Xunit;
+
+namespace Jellyfin.Plugin.DoesTheDogDie.E2ETests.Tests;
+
+[Trait("Category", "E2E")]
+[Collection("Jellyfin")]
+public sealed class ConfigPersistenceTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly JellyfinFixture _fixture;
+
+    public ConfigPersistenceTests(JellyfinFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task BoolFlag_EnableMovies_RoundTripsAfterPost()
+    {
+        try
+        {
+            await _fixture.Client.SetPluginConfigurationAsync(
+                JellyfinFixture.PluginId,
+                TestHelpers.ConfigWith(("EnableMovies", false)));
+
+            var fetched = await GetConfigAsync();
+            fetched.EnableMovies.Should().BeFalse("POSTed EnableMovies=false should be observable on next GET");
+            fetched.EnableSeries.Should().BeTrue("untouched defaults should still round-trip alongside the flipped flag");
+        }
+        finally
+        {
+            await ResetConfigAsync();
+        }
+    }
+
+    [Fact]
+    public async Task IntValue_MinVotesThreshold_RoundTripsAfterPost()
+    {
+        try
+        {
+            await _fixture.Client.SetPluginConfigurationAsync(
+                JellyfinFixture.PluginId,
+                TestHelpers.ConfigWith(("MinVotesThreshold", 42)));
+
+            var fetched = await GetConfigAsync();
+            fetched.MinVotesThreshold.Should().Be(42);
+        }
+        finally
+        {
+            await ResetConfigAsync();
+        }
+    }
+
+    [Fact]
+    public async Task StringValue_TagPrefix_RoundTripsAfterPost()
+    {
+        try
+        {
+            await _fixture.Client.SetPluginConfigurationAsync(
+                JellyfinFixture.PluginId,
+                TestHelpers.ConfigWith(("TagPrefix", "TRIGGER:"), ("SafeTagPrefix", "OK:")));
+
+            var fetched = await GetConfigAsync();
+            fetched.TagPrefix.Should().Be("TRIGGER:");
+            fetched.SafeTagPrefix.Should().Be("OK:");
+        }
+        finally
+        {
+            await ResetConfigAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ListValue_EnabledCategoryIds_RoundTripsAfterPost()
+    {
+        try
+        {
+            await _fixture.Client.SetPluginConfigurationAsync(
+                JellyfinFixture.PluginId,
+                TestHelpers.ConfigWith(
+                    ("ShowAllTriggers", false),
+                    ("EnabledCategoryIds", new[] { 7, 13, 21 })));
+
+            var fetched = await GetConfigAsync();
+            fetched.ShowAllTriggers.Should().BeFalse();
+            fetched.EnabledCategoryIds.Should().BeEquivalentTo(new[] { 7, 13, 21 });
+        }
+        finally
+        {
+            await ResetConfigAsync();
+        }
+    }
+
+    [Fact(Skip = "Requires feature/description-injection to be merged")]
+    public async Task DescriptionInjectionFlags_RoundTripTogetherAfterPost()
+    {
+        try
+        {
+            await _fixture.Client.SetPluginConfigurationAsync(
+                JellyfinFixture.PluginId,
+                TestHelpers.ConfigWith(
+                    ("AddDescriptionWarnings", true),
+                    ("IncludeTopComment", true),
+                    ("MaxCommentLength", 77),
+                    ("HideSpoilerComments", false)));
+
+            var fetched = await GetConfigAsync();
+            fetched.AddDescriptionWarnings.Should().BeTrue();
+            fetched.IncludeTopComment.Should().BeTrue();
+            fetched.MaxCommentLength.Should().Be(77);
+            fetched.HideSpoilerComments.Should().BeFalse();
+        }
+        finally
+        {
+            await ResetConfigAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Configuration_SurvivesItemRefresh()
+    {
+        var movies = await _fixture.Client.GetItemsAsync("Movie");
+        var johnWick = movies.Single(m => m.Name == "John Wick");
+
+        try
+        {
+            await _fixture.Client.SetPluginConfigurationAsync(
+                JellyfinFixture.PluginId,
+                TestHelpers.ConfigWith(("MinVotesThreshold", 123), ("TagPrefix", "WARN:")));
+
+            // Refresh exercises the provider pipeline; config must not be reset by it.
+            await _fixture.Client.RefreshItemMetadataAsync(johnWick.Id, replaceAllMetadata: true);
+
+            var fetched = await GetConfigAsync();
+            fetched.MinVotesThreshold.Should().Be(123, "item refresh must not clobber plugin config");
+            fetched.TagPrefix.Should().Be("WARN:");
+        }
+        finally
+        {
+            await ResetConfigAsync();
+            await _fixture.Client.RefreshItemMetadataAsync(johnWick.Id, replaceAllMetadata: true);
+        }
+    }
+
+    private async Task<PluginConfigDto> GetConfigAsync()
+    {
+        using var doc = await _fixture.Client.GetPluginConfigurationAsync(JellyfinFixture.PluginId);
+        var dto = JsonSerializer.Deserialize<PluginConfigDto>(doc.RootElement.GetRawText(), JsonOptions);
+        dto.Should().NotBeNull("Jellyfin should return a JSON object for the plugin configuration");
+        return dto!;
+    }
+
+    private async Task ResetConfigAsync()
+    {
+        await _fixture.Client.SetPluginConfigurationAsync(
+            JellyfinFixture.PluginId,
+            TestHelpers.DefaultPluginConfig());
+    }
+
+    private sealed class PluginConfigDto
+    {
+        public bool EnableMovies { get; set; }
+
+        public bool EnableSeries { get; set; }
+
+        public bool EnableBooks { get; set; }
+
+        public int MinVotesThreshold { get; set; }
+
+        public string TagPrefix { get; set; } = string.Empty;
+
+        public string SafeTagPrefix { get; set; } = string.Empty;
+
+        public bool ShowAllTriggers { get; set; }
+
+        public int[] EnabledCategoryIds { get; set; } = System.Array.Empty<int>();
+
+        public int[] EnabledTopicIds { get; set; } = System.Array.Empty<int>();
+
+        public bool AddDescriptionWarnings { get; set; }
+
+        public bool IncludeTopComment { get; set; }
+
+        public int MaxCommentLength { get; set; }
+
+        public bool HideSpoilerComments { get; set; }
+    }
+}

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/ConfigurationTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/ConfigurationTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Jellyfin.Plugin.DoesTheDogDie.E2ETests.Fixtures;
+using Xunit;
+
+namespace Jellyfin.Plugin.DoesTheDogDie.E2ETests.Tests;
+
+[Trait("Category", "E2E")]
+[Collection("Jellyfin")]
+public sealed class ConfigurationTests
+{
+    private readonly JellyfinFixture _fixture;
+
+    public ConfigurationTests(JellyfinFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task MinVotesThreshold_FiltersAllTriggers_WhenSetAboveStubVoteCount()
+    {
+        var movies = await _fixture.Client.GetItemsAsync("Movie");
+        var johnWick = movies.Single(m => m.Name == "John Wick");
+
+        try
+        {
+            await _fixture.Client.SetPluginConfigurationAsync(
+                JellyfinFixture.PluginId,
+                TestHelpers.ConfigWith(("MinVotesThreshold", 10000)));
+            // replaceAllMetadata=true so DtddMovieProvider re-runs even though Dtdd ProviderId
+            // is already set from the initial scan.
+            await _fixture.Client.RefreshItemMetadataAsync(johnWick.Id, replaceAllMetadata: true);
+
+            await TestHelpers.WaitForAsync(
+                async () =>
+                {
+                    var refreshed = (await _fixture.Client.GetItemsAsync("Movie")).Single(m => m.Name == "John Wick");
+                    return !refreshed.Tags.Any(t => t.StartsWith("CW:", StringComparison.Ordinal));
+                },
+                TimeSpan.FromSeconds(30),
+                failureMessage: "Expected all CW: tags removed once MinVotesThreshold exceeds stub vote counts");
+        }
+        finally
+        {
+            await _fixture.Client.SetPluginConfigurationAsync(JellyfinFixture.PluginId, TestHelpers.DefaultPluginConfig());
+            await _fixture.Client.RefreshItemMetadataAsync(johnWick.Id, replaceAllMetadata: true);
+            await TestHelpers.WaitForAsync(
+                async () =>
+                {
+                    var refreshed = (await _fixture.Client.GetItemsAsync("Movie")).Single(m => m.Name == "John Wick");
+                    return refreshed.Tags.Contains("CW: an animal dies");
+                },
+                TimeSpan.FromSeconds(30),
+                failureMessage: "Cleanup: tags did not return after restoring default config");
+        }
+    }
+}

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/DescriptionInjectionContentTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/DescriptionInjectionContentTests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Jellyfin.Plugin.DoesTheDogDie.E2ETests.Fixtures;
+using Xunit;
+
+namespace Jellyfin.Plugin.DoesTheDogDie.E2ETests.Tests;
+
+/// <summary>
+/// Asserts the exact content shape that OverviewFormatter injects between the
+/// <c>&lt;!-- DTDD_START --&gt;</c> / <c>&lt;!-- DTDD_END --&gt;</c> markers — heading,
+/// per-trigger warning lines with vote counts, and content omission when triggers
+/// fall under MinVotesThreshold.
+/// </summary>
+[Trait("Category", "E2E")]
+[Collection("Jellyfin")]
+public sealed class DescriptionInjectionContentTests
+{
+    private const string DtddStartMarker = "<!-- DTDD_START -->";
+    private const string DtddEndMarker = "<!-- DTDD_END -->";
+
+    private readonly JellyfinFixture _fixture;
+
+    public DescriptionInjectionContentTests(JellyfinFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(Skip = "Requires feature/description-injection to be merged")]
+    public async Task InjectedOverview_ContainsContentWarningsHeading()
+    {
+        var johnWick = await GetJohnWickAsync();
+
+        try
+        {
+            await EnableInjectionAndRefreshAsync(johnWick.Id);
+            var refreshed = await WaitForInjectedAsync();
+            refreshed.Overview.Should().Contain("**Content Warnings** (via DoesTheDogDie)",
+                "OverviewFormatter writes a fixed markdown heading above the trigger lines");
+        }
+        finally
+        {
+            await DisableInjectionAndRefreshAsync(johnWick.Id);
+        }
+    }
+
+    [Fact(Skip = "Requires feature/description-injection to be merged")]
+    public async Task InjectedOverview_ContainsTriggerLines_WithCapitalizedNameAndVoteCounts()
+    {
+        var johnWick = await GetJohnWickAsync();
+
+        try
+        {
+            await EnableInjectionAndRefreshAsync(johnWick.Id);
+            var refreshed = await WaitForInjectedAsync();
+
+            // Stub yesSum/noSum: "an animal dies" 87/4, "someone is shot" 256/8.
+            // OverviewFormatter capitalizes first letter and emits "⚠️ {Name} ({Yes} yes / {No} no)".
+            refreshed.Overview.Should().Contain("⚠️ An animal dies (87 yes / 4 no)");
+            refreshed.Overview.Should().Contain("⚠️ Someone is shot (256 yes / 8 no)");
+        }
+        finally
+        {
+            await DisableInjectionAndRefreshAsync(johnWick.Id);
+        }
+    }
+
+    [Fact(Skip = "Requires feature/description-injection to be merged")]
+    public async Task InjectedOverview_OmitsLowVoteTrigger_WhenAboveMinVotesThreshold()
+    {
+        var johnWick = await GetJohnWickAsync();
+
+        try
+        {
+            // "an animal dies" total = 91, "someone is shot" total = 264.
+            // Threshold 100 must drop the first but keep the second.
+            await _fixture.Client.SetPluginConfigurationAsync(
+                JellyfinFixture.PluginId,
+                TestHelpers.ConfigWith(("AddDescriptionWarnings", true), ("MinVotesThreshold", 100)));
+            await _fixture.Client.RefreshItemMetadataAsync(johnWick.Id, replaceAllMetadata: true);
+
+            await TestHelpers.WaitForAsync(
+                async () =>
+                {
+                    var current = (await _fixture.Client.GetItemsAsync("Movie")).Single(m => m.Name == "John Wick");
+                    return current.Overview is not null
+                        && current.Overview.Contains("Someone is shot", StringComparison.Ordinal);
+                },
+                TimeSpan.FromSeconds(30),
+                failureMessage: "Expected high-vote trigger to appear after refresh with MinVotesThreshold=100");
+
+            var refreshed = (await _fixture.Client.GetItemsAsync("Movie")).Single(m => m.Name == "John Wick");
+            refreshed.Overview.Should().Contain(DtddStartMarker, "high-vote trigger should still keep the DTDD section present");
+            refreshed.Overview.Should().Contain("Someone is shot", "264-total trigger should pass a 100-vote threshold");
+            refreshed.Overview.Should().NotContain("An animal dies", "91-total trigger should be filtered out at MinVotesThreshold=100");
+        }
+        finally
+        {
+            await DisableInjectionAndRefreshAsync(johnWick.Id);
+        }
+    }
+
+    [Fact]
+    public async Task InjectedOverview_OmitsAllTriggers_WhenMinVotesExceedsAllStubVotes()
+    {
+        var johnWick = await GetJohnWickAsync();
+
+        try
+        {
+            await _fixture.Client.SetPluginConfigurationAsync(
+                JellyfinFixture.PluginId,
+                TestHelpers.ConfigWith(("AddDescriptionWarnings", true), ("MinVotesThreshold", 100000)));
+            await _fixture.Client.RefreshItemMetadataAsync(johnWick.Id, replaceAllMetadata: true);
+
+            // Give the refresh a window to (incorrectly) inject markers; OverviewFormatter
+            // returns empty when no triggers survive filtering, so AppendToOverview leaves
+            // the existing overview untouched — no DTDD markers should appear.
+            await Task.Delay(TimeSpan.FromSeconds(5));
+
+            var refreshed = (await _fixture.Client.GetItemsAsync("Movie")).Single(m => m.Name == "John Wick");
+            (refreshed.Overview ?? string.Empty).Should().NotContain(DtddStartMarker,
+                "no triggers survive filtering, so the formatter must not emit a DTDD section");
+            (refreshed.Overview ?? string.Empty).Should().NotContain(DtddEndMarker);
+        }
+        finally
+        {
+            await DisableInjectionAndRefreshAsync(johnWick.Id);
+        }
+    }
+
+    [Fact(Skip = "Requires feature/description-injection to be merged")]
+    public async Task InjectedOverview_IsBoundedByDtddMarkers()
+    {
+        var johnWick = await GetJohnWickAsync();
+
+        try
+        {
+            await EnableInjectionAndRefreshAsync(johnWick.Id);
+            var refreshed = await WaitForInjectedAsync();
+
+            var overview = refreshed.Overview!;
+            var start = overview.IndexOf(DtddStartMarker, StringComparison.Ordinal);
+            var end = overview.IndexOf(DtddEndMarker, StringComparison.Ordinal);
+
+            start.Should().BeGreaterThanOrEqualTo(0);
+            end.Should().BeGreaterThan(start, "end marker must follow start marker so the section is well-formed");
+
+            var section = overview.Substring(start, (end + DtddEndMarker.Length) - start);
+            section.Should().Contain("**Content Warnings**", "the heading must live inside the marker-bounded section");
+            section.Should().Contain("An animal dies", "trigger lines must live inside the marker-bounded section, not before/after");
+        }
+        finally
+        {
+            await DisableInjectionAndRefreshAsync(johnWick.Id);
+        }
+    }
+
+    private async Task<JellyfinClient.JellyfinItemDto> GetJohnWickAsync()
+    {
+        var movies = await _fixture.Client.GetItemsAsync("Movie");
+        return movies.Single(m => m.Name == "John Wick");
+    }
+
+    private async Task EnableInjectionAndRefreshAsync(string itemId)
+    {
+        await _fixture.Client.SetPluginConfigurationAsync(
+            JellyfinFixture.PluginId,
+            TestHelpers.ConfigWith(("AddDescriptionWarnings", true)));
+        await _fixture.Client.RefreshItemMetadataAsync(itemId, replaceAllMetadata: true);
+    }
+
+    private async Task DisableInjectionAndRefreshAsync(string itemId)
+    {
+        await _fixture.Client.SetPluginConfigurationAsync(JellyfinFixture.PluginId, TestHelpers.DefaultPluginConfig());
+        await _fixture.Client.RefreshItemMetadataAsync(itemId, replaceAllMetadata: true);
+        await TestHelpers.WaitForAsync(
+            async () =>
+            {
+                var refreshed = (await _fixture.Client.GetItemsAsync("Movie")).Single(m => m.Name == "John Wick");
+                return refreshed.Overview is null
+                    || !refreshed.Overview.Contains(DtddStartMarker, StringComparison.Ordinal);
+            },
+            TimeSpan.FromSeconds(30),
+            failureMessage: "Cleanup: DTDD markers should be removed after disabling AddDescriptionWarnings");
+    }
+
+    private async Task<JellyfinClient.JellyfinItemDto> WaitForInjectedAsync()
+    {
+        await TestHelpers.WaitForAsync(
+            async () =>
+            {
+                var current = (await _fixture.Client.GetItemsAsync("Movie")).Single(m => m.Name == "John Wick");
+                return current.Overview is not null
+                    && current.Overview.Contains(DtddStartMarker, StringComparison.Ordinal)
+                    && current.Overview.Contains(DtddEndMarker, StringComparison.Ordinal);
+            },
+            TimeSpan.FromSeconds(30),
+            failureMessage: "Expected DTDD markers in Overview after enabling AddDescriptionWarnings");
+
+        return (await _fixture.Client.GetItemsAsync("Movie")).Single(m => m.Name == "John Wick");
+    }
+}

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/DescriptionInjectionContentTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/DescriptionInjectionContentTests.cs
@@ -178,11 +178,15 @@ public sealed class DescriptionInjectionContentTests
             async () =>
             {
                 var refreshed = (await _fixture.Client.GetItemsAsync("Movie")).Single(m => m.Name == "John Wick");
-                return refreshed.Overview is null
-                    || !refreshed.Overview.Contains(DtddStartMarker, StringComparison.Ordinal);
+
+                // Tags must be restored too: the test body may have raised MinVotesThreshold,
+                // stripping CW: tags; later tests rely on the default-config tag state.
+                return (refreshed.Overview is null
+                    || !refreshed.Overview.Contains(DtddStartMarker, StringComparison.Ordinal))
+                    && refreshed.Tags.Contains("CW: an animal dies");
             },
             TimeSpan.FromSeconds(30),
-            failureMessage: "Cleanup: DTDD markers should be removed after disabling AddDescriptionWarnings");
+            failureMessage: "Cleanup: DTDD markers should be removed and CW: tags restored after resetting config");
     }
 
     private async Task<JellyfinClient.JellyfinItemDto> WaitForInjectedAsync()

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/InheritanceTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/InheritanceTests.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Jellyfin.Plugin.DoesTheDogDie.E2ETests.Fixtures;
+using Xunit;
+
+namespace Jellyfin.Plugin.DoesTheDogDie.E2ETests.Tests;
+
+[Trait("Category", "E2E")]
+[Collection("Jellyfin")]
+public sealed class InheritanceTests
+{
+    private readonly JellyfinFixture _fixture;
+
+    public InheritanceTests(JellyfinFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task Episode_InheritsDtddIdFromSeries()
+    {
+        var episodes = await _fixture.Client.GetItemsAsync("Episode");
+        var pilot = episodes.SingleOrDefault(e => e.Name == "Pilot");
+
+        pilot.Should().NotBeNull("Breaking Bad S01E01 fixture should have been scanned");
+        pilot!.ProviderIds.Should().ContainKey("Dtdd")
+            .WhoseValue.Should().Be("5678", "episode should inherit parent series' DTDD id");
+    }
+
+    [Fact]
+    public async Task Season_InheritsDtddIdFromSeries()
+    {
+        var seasons = await _fixture.Client.GetItemsAsync("Season");
+        var s1 = seasons.SingleOrDefault(s => s.SeriesId is not null);
+
+        s1.Should().NotBeNull();
+        s1!.ProviderIds.Should().ContainKey("Dtdd").WhoseValue.Should().Be("5678");
+    }
+}

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/MovieMetadataTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/MovieMetadataTests.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Jellyfin.Plugin.DoesTheDogDie.E2ETests.Fixtures;
+using Xunit;
+
+namespace Jellyfin.Plugin.DoesTheDogDie.E2ETests.Tests;
+
+[Trait("Category", "E2E")]
+[Collection("Jellyfin")]
+public sealed class MovieMetadataTests
+{
+    private readonly JellyfinFixture _fixture;
+
+    public MovieMetadataTests(JellyfinFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task JohnWick_GetsDtddProviderId()
+    {
+        var movies = await _fixture.Client.GetItemsAsync("Movie");
+        var johnWick = movies.SingleOrDefault(m => m.Name == "John Wick");
+
+        johnWick.Should().NotBeNull("John Wick fixture should have been scanned");
+        johnWick!.ProviderIds.Should().ContainKey("Dtdd")
+            .WhoseValue.Should().Be("1234", "WireMock stub returns DTDD id 1234 for tt2911666");
+    }
+
+    [Fact]
+    public async Task JohnWick_GetsCwTagsForPositiveTriggers()
+    {
+        var movies = await _fixture.Client.GetItemsAsync("Movie");
+        var johnWick = movies.Single(m => m.Name == "John Wick");
+
+        johnWick.Tags.Should().Contain(t => t.StartsWith("CW:"), "stub triggers exceed default vote threshold");
+        johnWick.Tags.Should().Contain("CW: an animal dies");
+        johnWick.Tags.Should().Contain("CW: someone is shot");
+    }
+}

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/OverviewInjectionTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/OverviewInjectionTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Jellyfin.Plugin.DoesTheDogDie.E2ETests.Fixtures;
+using Xunit;
+
+namespace Jellyfin.Plugin.DoesTheDogDie.E2ETests.Tests;
+
+[Trait("Category", "E2E")]
+[Collection("Jellyfin")]
+public sealed class OverviewInjectionTests
+{
+    private const string DtddStartMarker = "<!-- DTDD_START -->";
+    private const string DtddEndMarker = "<!-- DTDD_END -->";
+
+    private readonly JellyfinFixture _fixture;
+
+    public OverviewInjectionTests(JellyfinFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(Skip = "Requires feature/description-injection to be merged")]
+    public async Task AddDescriptionWarnings_InjectsMarkersIntoOverview()
+    {
+        var movies = await _fixture.Client.GetItemsAsync("Movie");
+        var johnWick = movies.Single(m => m.Name == "John Wick");
+        var originalOverview = johnWick.Overview;
+
+        try
+        {
+            await _fixture.Client.SetPluginConfigurationAsync(
+                JellyfinFixture.PluginId,
+                TestHelpers.ConfigWith(("AddDescriptionWarnings", true)));
+            await _fixture.Client.RefreshItemMetadataAsync(johnWick.Id, replaceAllMetadata: true);
+
+            await TestHelpers.WaitForAsync(
+                async () =>
+                {
+                    var refreshed = (await _fixture.Client.GetItemsAsync("Movie")).Single(m => m.Name == "John Wick");
+                    return refreshed.Overview is not null
+                        && refreshed.Overview.Contains(DtddStartMarker, StringComparison.Ordinal)
+                        && refreshed.Overview.Contains(DtddEndMarker, StringComparison.Ordinal);
+                },
+                TimeSpan.FromSeconds(30),
+                failureMessage: "Expected DTDD overview markers after enabling AddDescriptionWarnings");
+
+            var result = (await _fixture.Client.GetItemsAsync("Movie")).Single(m => m.Name == "John Wick");
+            result.Overview.Should().Contain("An animal dies", "trigger names (capitalized) should appear in injected overview text");
+        }
+        finally
+        {
+            await _fixture.Client.SetPluginConfigurationAsync(JellyfinFixture.PluginId, TestHelpers.DefaultPluginConfig());
+            await _fixture.Client.RefreshItemMetadataAsync(johnWick.Id, replaceAllMetadata: true);
+            await TestHelpers.WaitForAsync(
+                async () =>
+                {
+                    var refreshed = (await _fixture.Client.GetItemsAsync("Movie")).Single(m => m.Name == "John Wick");
+                    return refreshed.Overview is null
+                        || !refreshed.Overview.Contains(DtddStartMarker, StringComparison.Ordinal);
+                },
+                TimeSpan.FromSeconds(30),
+                failureMessage: "Cleanup: DTDD markers should be removed after disabling AddDescriptionWarnings");
+        }
+    }
+
+    [Fact]
+    public async Task LockedOverview_NotModified_WhenAddDescriptionWarningsEnabled()
+    {
+        var movies = await _fixture.Client.GetItemsAsync("Movie");
+        var johnWick = movies.Single(m => m.Name == "John Wick");
+
+        try
+        {
+            await _fixture.Client.LockOverviewAsync(johnWick.Id);
+            await _fixture.Client.SetPluginConfigurationAsync(
+                JellyfinFixture.PluginId,
+                TestHelpers.ConfigWith(("AddDescriptionWarnings", true)));
+            await _fixture.Client.RefreshItemMetadataAsync(johnWick.Id, replaceAllMetadata: true);
+
+            // Give the refresh a chance to (incorrectly) write — but we expect it not to.
+            await Task.Delay(TimeSpan.FromSeconds(5));
+
+            var refreshed = (await _fixture.Client.GetItemsAsync("Movie")).Single(m => m.Name == "John Wick");
+            refreshed.Overview.Should().NotContain(DtddStartMarker, "locked Overview must not be modified");
+        }
+        finally
+        {
+            await _fixture.Client.UnlockAllFieldsAsync(johnWick.Id);
+            await _fixture.Client.SetPluginConfigurationAsync(JellyfinFixture.PluginId, TestHelpers.DefaultPluginConfig());
+            await _fixture.Client.RefreshItemMetadataAsync(johnWick.Id, replaceAllMetadata: true);
+        }
+    }
+}

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/SeriesMetadataTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.E2ETests/Tests/SeriesMetadataTests.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Jellyfin.Plugin.DoesTheDogDie.E2ETests.Fixtures;
+using Xunit;
+
+namespace Jellyfin.Plugin.DoesTheDogDie.E2ETests.Tests;
+
+[Trait("Category", "E2E")]
+[Collection("Jellyfin")]
+public sealed class SeriesMetadataTests
+{
+    private readonly JellyfinFixture _fixture;
+
+    public SeriesMetadataTests(JellyfinFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task BreakingBad_Series_GetsDtddProviderIdAndTag()
+    {
+        var series = await _fixture.Client.GetItemsAsync("Series");
+        var breakingBad = series.SingleOrDefault(s => s.Name == "Breaking Bad");
+
+        breakingBad.Should().NotBeNull("Breaking Bad fixture should have been scanned");
+        breakingBad!.ProviderIds.Should().ContainKey("Dtdd").WhoseValue.Should().Be("5678");
+        breakingBad.Tags.Should().Contain("CW: someone dies");
+    }
+}

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/Providers/DtddMovieProviderTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/Providers/DtddMovieProviderTests.cs
@@ -280,6 +280,35 @@ public class DtddMovieProviderTests
     }
 
     [Fact]
+    public async Task FetchAsync_ShowConfidenceInTags_AppendsConfidencePercentage()
+    {
+        // Arrange
+        SetupConfiguration(new PluginConfiguration
+        {
+            EnableMovies = true,
+            AddWarningTags = true,
+            TagPrefix = "CW:",
+            MinVotesThreshold = 0,
+            ShowConfidenceInTags = true
+        });
+        var movie = CreateMovie("tt2911666");
+
+        var details = CreateMediaDetailsWithTriggers(15713, "John Wick");
+        _apiClientMock
+            .Setup(x => x.GetMediaDetailsByImdbIdAsync("tt2911666", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        // Act
+        var result = await _provider.FetchAsync(movie, _defaultOptions, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(ItemUpdateType.MetadataDownload, result);
+
+        // "a dog dies" has 1336 yes / 118 no => Wilson confidence 0.904 => 90%
+        Assert.Contains("CW: a dog dies (90%)", movie.Tags);
+    }
+
+    [Fact]
     public async Task FetchAsync_MinVotesThreshold_FiltersTriggers()
     {
         // Arrange

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/ScheduledTasks/DtddRefreshTaskTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/ScheduledTasks/DtddRefreshTaskTests.cs
@@ -445,6 +445,121 @@ public class DtddRefreshTaskTests
         Assert.Contains("Safe: a dog dies", movie.Tags);
     }
 
+    [Fact]
+    public async Task ExecuteAsync_WithTagsEnabled_CallsUpdateToRepositoryAsync()
+    {
+        // Arrange
+        var config = new PluginConfiguration
+        {
+            EnableMovies = true,
+            EnableSeries = false,
+            AddWarningTags = true,
+            TagPrefix = "CW:",
+            MinVotesThreshold = 0
+        };
+        _configAccessorMock.Setup(x => x.GetConfiguration()).Returns(config);
+
+        var movieMock = new Mock<Movie> { CallBase = true };
+        movieMock.Object.Name = "Test Movie";
+        movieMock.Object.Tags = Array.Empty<string>();
+        movieMock.Object.SetProviderId(MetadataProvider.Imdb, "tt2911666");
+        movieMock.Object.SetProviderId(Constants.ProviderId, "15713");
+        movieMock.Setup(x => x.UpdateToRepositoryAsync(It.IsAny<MediaBrowser.Controller.Library.ItemUpdateType>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _libraryManagerMock
+            .Setup(x => x.GetItemList(It.IsAny<InternalItemsQuery>()))
+            .Returns(new BaseItem[] { movieMock.Object });
+
+        var details = CreateMediaDetailsWithTriggers(15713, "John Wick");
+        _apiClientMock
+            .Setup(x => x.GetMediaDetailsByImdbIdAsync("tt2911666", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        // Act
+        await _task.ExecuteAsync(new Mock<IProgress<double>>().Object, CancellationToken.None);
+
+        // Assert
+        movieMock.Verify(
+            x => x.UpdateToRepositoryAsync(MediaBrowser.Controller.Library.ItemUpdateType.MetadataEdit, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithTagsDisabled_StillCallsUpdateToRepositoryAsync()
+    {
+        // Arrange
+        var config = new PluginConfiguration
+        {
+            EnableMovies = true,
+            EnableSeries = false,
+            AddWarningTags = false
+        };
+        _configAccessorMock.Setup(x => x.GetConfiguration()).Returns(config);
+
+        var movieMock = new Mock<Movie> { CallBase = true };
+        movieMock.Object.Name = "Test Movie";
+        movieMock.Object.Tags = Array.Empty<string>();
+        movieMock.Object.SetProviderId(MetadataProvider.Imdb, "tt2911666");
+        movieMock.Object.SetProviderId(Constants.ProviderId, "15713");
+        movieMock.Setup(x => x.UpdateToRepositoryAsync(It.IsAny<MediaBrowser.Controller.Library.ItemUpdateType>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _libraryManagerMock
+            .Setup(x => x.GetItemList(It.IsAny<InternalItemsQuery>()))
+            .Returns(new BaseItem[] { movieMock.Object });
+
+        var details = CreateMediaDetailsWithTriggers(15713, "John Wick");
+        _apiClientMock
+            .Setup(x => x.GetMediaDetailsByImdbIdAsync("tt2911666", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        // Act
+        await _task.ExecuteAsync(new Mock<IProgress<double>>().Object, CancellationToken.None);
+
+        // Assert - must persist even when tagging is disabled (DTDD provider ID still needs saving)
+        movieMock.Verify(
+            x => x.UpdateToRepositoryAsync(MediaBrowser.Controller.Library.ItemUpdateType.MetadataEdit, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ItemWithOnlyImdbId_IsProcessedOnFreshInstall()
+    {
+        // Arrange - item has IMDB ID but no DTDD ID (fresh install scenario)
+        var config = new PluginConfiguration
+        {
+            EnableMovies = true,
+            EnableSeries = false,
+            AddWarningTags = true,
+            TagPrefix = "CW:",
+            MinVotesThreshold = 0
+        };
+        _configAccessorMock.Setup(x => x.GetConfiguration()).Returns(config);
+
+        var movie = new Movie { Name = "Test Movie", Tags = Array.Empty<string>() };
+        movie.SetProviderId(MetadataProvider.Imdb, "tt2911666");
+        // No DTDD provider ID set
+
+        _libraryManagerMock
+            .Setup(x => x.GetItemList(It.IsAny<InternalItemsQuery>()))
+            .Returns(new BaseItem[] { movie });
+
+        var details = CreateMediaDetailsWithTriggers(15713, "John Wick");
+        _apiClientMock
+            .Setup(x => x.GetMediaDetailsByImdbIdAsync("tt2911666", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        // Act
+        await _task.ExecuteAsync(new Mock<IProgress<double>>().Object, CancellationToken.None);
+
+        // Assert - item should be fetched and tagged even without a pre-existing DTDD ID
+        _apiClientMock.Verify(
+            x => x.GetMediaDetailsByImdbIdAsync("tt2911666", It.IsAny<CancellationToken>()),
+            Times.Once);
+        Assert.Contains("CW: a dog dies", movie.Tags);
+    }
+
     private static Movie CreateMovie(string imdbId, string dtddId)
     {
         var movie = new Movie

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/Scoring/BetaConfidenceCalculatorTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/Scoring/BetaConfidenceCalculatorTests.cs
@@ -1,0 +1,96 @@
+using Jellyfin.Plugin.DoesTheDogDie.Scoring;
+using Xunit;
+
+namespace Jellyfin.Plugin.DoesTheDogDie.Tests.Scoring;
+
+public class BetaConfidenceCalculatorTests
+{
+    [Fact]
+    public void CalculateConfidence_ZeroVotes_ReturnsZero()
+    {
+        // Act
+        var result = BetaConfidenceCalculator.CalculateConfidence(0, 0);
+
+        // Assert
+        Assert.Equal(0.0, result);
+    }
+
+    [Fact]
+    public void CalculateConfidence_ZeroPositiveVotes_ReturnsZero()
+    {
+        // Act
+        var result = BetaConfidenceCalculator.CalculateConfidence(0, 10);
+
+        // Assert
+        Assert.Equal(0.0, result);
+    }
+
+    [Theory]
+    [InlineData(1, 1, 0.206543)] // Single unanimous vote - low confidence
+    [InlineData(10, 10, 0.722460)] // 10 unanimous votes - high confidence
+    [InlineData(100, 100, 0.963005)] // 100 unanimous votes - very high confidence
+    [InlineData(50, 100, 0.403830)] // Equal split - below 50%
+    [InlineData(3, 3, 0.438494)] // Default vote threshold, unanimous
+    [InlineData(75, 100, 0.656954)] // 75% agreement with good sample size
+    [InlineData(1336, 1454, 0.903680)] // Real-world example from DTDD
+    public void CalculateConfidence_KnownValues_ReturnsWilsonLowerBound(
+        int positiveVotes,
+        int totalVotes,
+        double expected)
+    {
+        // Act
+        var result = BetaConfidenceCalculator.CalculateConfidence(positiveVotes, totalVotes);
+
+        // Assert
+        Assert.Equal(expected, result, precision: 6);
+    }
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(5, 10)]
+    [InlineData(1000, 1000)]
+    public void CalculateConfidence_AnyInput_ReturnsValueBetweenZeroAndOne(
+        int positiveVotes,
+        int totalVotes)
+    {
+        // Act
+        var result = BetaConfidenceCalculator.CalculateConfidence(positiveVotes, totalVotes);
+
+        // Assert
+        Assert.InRange(result, 0.0, 1.0);
+    }
+
+    [Fact]
+    public void CalculateConfidence_MoreVotesSameRatio_IncreasesConfidence()
+    {
+        // Arrange - same 100% yes ratio with increasing sample sizes
+        var lowSample = BetaConfidenceCalculator.CalculateConfidence(2, 2);
+        var midSample = BetaConfidenceCalculator.CalculateConfidence(20, 20);
+        var highSample = BetaConfidenceCalculator.CalculateConfidence(200, 200);
+
+        // Assert
+        Assert.True(lowSample < midSample);
+        Assert.True(midSample < highSample);
+    }
+
+    [Fact]
+    public void CalculateConfidence_NegativeVotes_ReturnsZero()
+    {
+        // Act
+        var result = BetaConfidenceCalculator.CalculateConfidence(-1, 10);
+
+        // Assert
+        Assert.Equal(0.0, result);
+    }
+
+    [Fact]
+    public void CalculateConfidence_PositiveExceedsTotal_ClampsToTotal()
+    {
+        // Arrange - defensive: malformed data where yes > total
+        var clamped = BetaConfidenceCalculator.CalculateConfidence(15, 10);
+        var unanimous = BetaConfidenceCalculator.CalculateConfidence(10, 10);
+
+        // Assert
+        Assert.Equal(unanimous, clamped, precision: 6);
+    }
+}

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/Services/DtddLibraryScanServiceTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/Services/DtddLibraryScanServiceTests.cs
@@ -430,6 +430,43 @@ public class DtddLibraryScanServiceTests
         Assert.Contains("CW: a dog dies", movie.Tags);
     }
 
+    [Fact]
+    public void OnItemChanged_CallsUpdateToRepositoryAsync_AfterProcessing()
+    {
+        // Arrange
+        var config = new PluginConfiguration
+        {
+            EnableMovies = true,
+            AddWarningTags = true,
+            TagPrefix = "CW:",
+            MinVotesThreshold = 0
+        };
+        _configAccessorMock.Setup(x => x.GetConfiguration()).Returns(config);
+
+        var details = CreateMediaDetailsWithTriggers(15713, "John Wick");
+        _apiClientMock
+            .Setup(x => x.GetMediaDetailsByImdbIdAsync("tt2911666", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        var movieMock = new Mock<Movie> { CallBase = true };
+        movieMock.Object.Name = "Test Movie";
+        movieMock.Object.Tags = Array.Empty<string>();
+        movieMock.Object.SetProviderId(MetadataProvider.Imdb, "tt2911666");
+        movieMock.Setup(x => x.UpdateToRepositoryAsync(It.IsAny<MediaBrowser.Controller.Library.ItemUpdateType>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var eventArgs = new ItemChangeEventArgs { Item = movieMock.Object };
+
+        // Act
+        _service.OnItemChanged(null, eventArgs);
+
+        // Assert - wait for fire-and-forget async task
+        Thread.Sleep(200);
+        movieMock.Verify(
+            x => x.UpdateToRepositoryAsync(MediaBrowser.Controller.Library.ItemUpdateType.MetadataEdit, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     private static Movie CreateMovie(string imdbId)
     {
         var movie = new Movie

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/TriggerFilterTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/TriggerFilterTests.cs
@@ -261,13 +261,165 @@ public class TriggerFilterTests
         Assert.Equal("a dog dies", result[0].Topic?.Name);
     }
 
-    private static DtddTopicItemStat CreateTrigger(int categoryId, int topicId, string name = "test trigger")
+    [Fact]
+    public void PluginConfiguration_ConfidenceDefaults_AreBackwardCompatible()
+    {
+        // Arrange / Act
+        var config = new PluginConfiguration();
+
+        // Assert
+        Assert.False(config.UseConfidenceScoring);
+        Assert.Equal(0.7, config.MinConfidenceThreshold);
+    }
+
+    [Fact]
+    public void ShouldIncludeTrigger_ConfidenceScoringDisabled_IgnoresConfidence()
+    {
+        // Arrange - 1 yes / 0 no has Wilson confidence ~0.21, well below threshold
+        var config = new PluginConfiguration
+        {
+            ShowAllTriggers = true,
+            UseConfidenceScoring = false,
+            MinConfidenceThreshold = 0.7
+        };
+        var trigger = CreateTrigger(categoryId: 2, topicId: 153, yesSum: 1, noSum: 0);
+
+        // Act
+        var result = TriggerFilter.ShouldIncludeTrigger(trigger, config);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldIncludeTrigger_ConfidenceAboveThreshold_ReturnsTrue()
+    {
+        // Arrange - 100 yes / 0 no has Wilson confidence ~0.96
+        var config = new PluginConfiguration
+        {
+            ShowAllTriggers = true,
+            UseConfidenceScoring = true,
+            MinConfidenceThreshold = 0.7
+        };
+        var trigger = CreateTrigger(categoryId: 2, topicId: 153, yesSum: 100, noSum: 0);
+
+        // Act
+        var result = TriggerFilter.ShouldIncludeTrigger(trigger, config);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldIncludeTrigger_ConfidenceBelowThreshold_ReturnsFalse()
+    {
+        // Arrange - 3 yes / 0 no has Wilson confidence ~0.44
+        var config = new PluginConfiguration
+        {
+            ShowAllTriggers = true,
+            UseConfidenceScoring = true,
+            MinConfidenceThreshold = 0.7
+        };
+        var trigger = CreateTrigger(categoryId: 2, topicId: 153, yesSum: 3, noSum: 0);
+
+        // Act
+        var result = TriggerFilter.ShouldIncludeTrigger(trigger, config);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ShouldIncludeTrigger_NegativeTriggerHighConfidence_ReturnsTrue()
+    {
+        // Arrange - 0 yes / 100 no: confidence is measured on the majority
+        // (safe) direction, so this should pass the threshold
+        var config = new PluginConfiguration
+        {
+            ShowAllTriggers = true,
+            UseConfidenceScoring = true,
+            MinConfidenceThreshold = 0.7
+        };
+        var trigger = CreateTrigger(categoryId: 2, topicId: 153, yesSum: 0, noSum: 100);
+
+        // Act
+        var result = TriggerFilter.ShouldIncludeTrigger(trigger, config);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldIncludeTrigger_ConfidenceScoringEnabled_CategoryFilterStillApplies()
+    {
+        // Arrange - high confidence but category not enabled
+        var config = new PluginConfiguration
+        {
+            ShowAllTriggers = false,
+            EnabledCategoryIds = new List<int> { 3 },
+            UseConfidenceScoring = true,
+            MinConfidenceThreshold = 0.7
+        };
+        var trigger = CreateTrigger(categoryId: 2, topicId: 153, yesSum: 100, noSum: 0);
+
+        // Act
+        var result = TriggerFilter.ShouldIncludeTrigger(trigger, config);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void GetConfidence_ReturnsWilsonScoreOfMajorityDirection()
+    {
+        // Arrange
+        var positive = CreateTrigger(categoryId: 2, topicId: 153, yesSum: 100, noSum: 0);
+        var negative = CreateTrigger(categoryId: 2, topicId: 153, yesSum: 0, noSum: 100);
+
+        // Act / Assert - both unanimous with 100 votes => ~0.963
+        Assert.Equal(0.963005, TriggerFilter.GetConfidence(positive), precision: 6);
+        Assert.Equal(0.963005, TriggerFilter.GetConfidence(negative), precision: 6);
+    }
+
+    [Fact]
+    public void FilterTriggers_ConfidenceScoringEnabled_FiltersLowConfidence()
+    {
+        // Arrange
+        var config = new PluginConfiguration
+        {
+            ShowAllTriggers = true,
+            UseConfidenceScoring = true,
+            MinConfidenceThreshold = 0.7
+        };
+
+        var triggers = new List<DtddTopicItemStat>
+        {
+            CreateTrigger(categoryId: 2, topicId: 153, name: "a dog dies", yesSum: 100, noSum: 0),
+            CreateTrigger(categoryId: 2, topicId: 154, name: "a cat dies", yesSum: 2, noSum: 1),
+            CreateTrigger(categoryId: 2, topicId: 155, name: "a horse dies", yesSum: 50, noSum: 2)
+        };
+
+        // Act
+        var filtered = TriggerFilter.FilterTriggers(triggers, config);
+
+        // Assert
+        var result = new List<DtddTopicItemStat>(filtered);
+        Assert.Equal(2, result.Count);
+        Assert.DoesNotContain(result, t => t.Topic?.Name == "a cat dies");
+    }
+
+    private static DtddTopicItemStat CreateTrigger(
+        int categoryId,
+        int topicId,
+        string name = "test trigger",
+        int yesSum = 100,
+        int noSum = 10)
     {
         return new DtddTopicItemStat
         {
             TopicItemId = topicId * 100,
-            YesSum = 100,
-            NoSum = 10,
+            YesSum = yesSum,
+            NoSum = noSum,
             TopicId = topicId,
             Topic = new DtddTopic
             {

--- a/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/TriggerTagFormatterTests.cs
+++ b/tests/Jellyfin.Plugin.DoesTheDogDie.Tests/TriggerTagFormatterTests.cs
@@ -1,0 +1,104 @@
+using Jellyfin.Plugin.DoesTheDogDie.Api.Models;
+using Jellyfin.Plugin.DoesTheDogDie.Configuration;
+using Xunit;
+
+namespace Jellyfin.Plugin.DoesTheDogDie.Tests;
+
+public class TriggerTagFormatterTests
+{
+    [Fact]
+    public void PluginConfiguration_ShowConfidenceInTags_DefaultsToFalse()
+    {
+        // Arrange / Act
+        var config = new PluginConfiguration();
+
+        // Assert
+        Assert.False(config.ShowConfidenceInTags);
+    }
+
+    [Fact]
+    public void FormatTagName_ConfidenceDisabled_ReturnsPlainTag()
+    {
+        // Arrange
+        var config = new PluginConfiguration { ShowConfidenceInTags = false };
+        var trigger = CreateTrigger("a dog dies", yesSum: 100, noSum: 0);
+
+        // Act
+        var result = TriggerTagFormatter.FormatTagName("CW:", trigger, config);
+
+        // Assert
+        Assert.Equal("CW: a dog dies", result);
+    }
+
+    [Fact]
+    public void FormatTagName_ConfidenceEnabled_AppendsPercentage()
+    {
+        // Arrange - 100 yes / 0 no => Wilson confidence 0.963 => 96.3% => 95%
+        var config = new PluginConfiguration { ShowConfidenceInTags = true };
+        var trigger = CreateTrigger("a dog dies", yesSum: 100, noSum: 0);
+
+        // Act
+        var result = TriggerTagFormatter.FormatTagName("CW:", trigger, config);
+
+        // Assert
+        Assert.Equal("CW: a dog dies (95%)", result);
+    }
+
+    [Theory]
+    [InlineData(10, 0, "70%")] // 0.722460 => 72.2% => 70%
+    [InlineData(1336, 118, "90%")] // 0.903680 => 90.4% => 90%
+    [InlineData(1, 0, "20%")] // 0.206543 => 20.7% => 20%
+    public void FormatTagName_ConfidenceEnabled_RoundsToNearestFivePercent(
+        int yesSum,
+        int noSum,
+        string expectedPercent)
+    {
+        // Arrange
+        var config = new PluginConfiguration { ShowConfidenceInTags = true };
+        var trigger = CreateTrigger("a dog dies", yesSum, noSum);
+
+        // Act
+        var result = TriggerTagFormatter.FormatTagName("CW:", trigger, config);
+
+        // Assert
+        Assert.Equal($"CW: a dog dies ({expectedPercent})", result);
+    }
+
+    [Fact]
+    public void FormatTagName_NegativeTrigger_UsesMajorityDirectionConfidence()
+    {
+        // Arrange - 0 yes / 100 no: safe confirmation with confidence 0.963 => 95%
+        var config = new PluginConfiguration { ShowConfidenceInTags = true };
+        var trigger = CreateTrigger("a cat dies", yesSum: 0, noSum: 100);
+
+        // Act
+        var result = TriggerTagFormatter.FormatTagName("Safe:", trigger, config);
+
+        // Assert
+        Assert.Equal("Safe: a cat dies (95%)", result);
+    }
+
+    [Fact]
+    public void FormatTagName_NullTopic_ReturnsNull()
+    {
+        // Arrange
+        var config = new PluginConfiguration();
+        var trigger = new DtddTopicItemStat { Topic = null };
+
+        // Act
+        var result = TriggerTagFormatter.FormatTagName("CW:", trigger, config);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    private static DtddTopicItemStat CreateTrigger(string name, int yesSum, int noSum)
+    {
+        return new DtddTopicItemStat
+        {
+            YesSum = yesSum,
+            NoSum = noSum,
+            Topic = new DtddTopic { Id = 153, Name = name }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Release PR for **0.1.1.0**, bringing `development` into `main`:

- **Milestone 1: Beta Distribution Confidence Rating** (#31) — Wilson score confidence calculator, confidence-based trigger filtering (`UseConfidenceScoring`, `MinConfidenceThreshold`), optional confidence percentage in tags (`ShowConfidenceInTags`), config page updates.
- **Tag persistence fixes** (#30) — tags now persist via `UpdateToRepositoryAsync`; refresh task seeds items without a DTDD id on fresh installs.
- **Automated E2E test suite** — Testcontainers + WireMock harness covering metadata, configuration, persistence, and inheritance, plus test-pollution fixes.
- JSON deserialization fix for verified fields.

## Test plan

- 219 unit tests passing
- 25 E2E tests passing (6 intentional skips pending description-injection)
- Release build clean with analyzers (0 warnings)

Closes #1
Closes #2
Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)